### PR TITLE
日付ベースのブログフォルダ構造と画像対応

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,9 @@
       "Bash(node scripts/generate-favicons.js:*)",
       "Bash(node scripts/generate-ico.js:*)",
       "Bash(git checkout:*)",
-      "Bash(npm run dev:*)"
+      "Bash(npm run dev:*)",
+      "Bash(git pull:*)",
+      "Bash(npm run copy-images:*)"
     ]
   }
 }

--- a/BLOG.md
+++ b/BLOG.md
@@ -6,25 +6,48 @@
 
 ### 1. 新しい記事ファイルを作成
 
-`src/content/blog/` ディレクトリに新しいMarkdownファイルを作成します。
+`src/content/blog/` ディレクトリに日付ベースのフォルダ構造で記事を作成します。
 
 ```bash
-# ファイル名の例
-src/content/blog/my-new-post.md
-src/content/blog/react-hooks-tutorial.md
+# フォルダ構造の例
+src/content/blog/2026/02/10/my-new-post/index.md
+src/content/blog/2026/02/15/react-hooks-tutorial/index.md
 ```
 
-**ファイル名のルール:**
-- 小文字とハイフンを使用（例: `my-article-title.md`）
+**フォルダ構造のルール:**
+- `年/月/日/記事名/index.md` の形式で作成
+- 記事名は小文字とハイフンを使用（例: `my-article-title`）
 - 日本語は避け、英数字とハイフン `-` のみ使用
-- このファイル名がURLの一部になります（例: `/blog/my-article-title`）
+- **画像は記事と同じフォルダに配置できます**（例: `image1.png`, `screenshot.jpg`）
+
+**フォルダ構造の例:**
+```
+src/content/blog/
+└── 2026/
+    └── 02/
+        ├── 10/
+        │   └── my-new-post/
+        │       ├── index.md      # 記事本文
+        │       ├── cover.png     # アイキャッチ画像
+        │       └── screenshot.jpg # 本文中の画像
+        └── 15/
+            └── react-tutorial/
+                └── index.md
+```
 
 ### 2. テンプレートを使用
 
 プロジェクトルートにある `blog-template.md` をコピーして使うと便利です。
 
 ```bash
-cp blog-template.md src/content/blog/your-article-name.md
+# 記事フォルダを作成
+mkdir -p "src/content/blog/2026/02/10/your-article-name"
+
+# テンプレートをコピー
+cp blog-template.md "src/content/blog/2026/02/10/your-article-name/index.md"
+
+# 編集
+# src/content/blog/2026/02/10/your-article-name/index.md
 ```
 
 ### 3. Frontmatter（メタデータ）を記入
@@ -38,6 +61,7 @@ description: "記事の説明文（SEO用）"
 pubDate: 2026-02-10T12:00:00
 author: reiblast1123
 tags: ["タグ1", "タグ2", "タグ3"]
+slug: my-article-slug
 draft: false
 ---
 ```
@@ -49,11 +73,17 @@ draft: false
 | `title` | ✅ | 記事のタイトル | `"TypeScriptの型推論入門"` |
 | `description` | ✅ | 記事の説明（SEO、OGP用） | `"TypeScriptの型推論について基礎から解説します"` |
 | `pubDate` | ✅ | 公開日時（ISO 8601形式） | `2026-02-10T12:00:00` |
+| `slug` | ✅ | URLに使用するスラグ（記事フォルダ名と同じ） | `"my-article-slug"` |
 | `author` | ❌ | 著者名（デフォルト: `reiblast1123`） | `"reiblast1123"` |
 | `tags` | ❌ | タグの配列 | `["TypeScript", "Web開発"]` |
-| `image` | ❌ | アイキャッチ画像のパス | `"/images/post-cover.jpg"` |
+| `image` | ❌ | アイキャッチ画像のパス | `"/images/blog/2026/02/10/my-article/cover.png"` |
 | `draft` | ❌ | 下書きフラグ（`true`で非公開） | `false` |
 | `updatedDate` | ❌ | 更新日時 | `2026-02-11T10:00:00` |
+
+**重要:** `slug` は記事のURLを決定します。フォルダ名と同じ値を設定してください。
+- フォルダ: `src/content/blog/2026/02/10/my-article-slug/index.md`
+- Slug: `my-article-slug`
+- URL: `/blog/my-article-slug`
 
 ### 4. 公開日時の指定
 
@@ -131,9 +161,28 @@ Frontmatterの後に、Markdown形式で記事本文を書きます。
 
 ### 画像
 
-```markdown
-![代替テキスト](/images/screenshot.png)
+記事フォルダ内に画像を配置できます。ビルド時に自動的に `public/images/blog/` にコピーされます。
+
+**画像の配置:**
 ```
+src/content/blog/2026/02/10/my-article/
+├── index.md
+├── cover.png        # アイキャッチ画像
+└── screenshot.jpg   # 本文中の画像
+```
+
+**Markdownでの参照:**
+```markdown
+# 同じフォルダの画像を参照（ビルド後のパスを指定）
+![スクリーンショット](/images/blog/2026/02/10/my-article/screenshot.jpg)
+
+# アイキャッチ画像（frontmatterで指定）
+---
+image: "/images/blog/2026/02/10/my-article/cover.png"
+---
+```
+
+**対応画像形式:** `.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, `.webp`, `.avif`
 
 ### コードブロック
 
@@ -193,9 +242,9 @@ npm run build
 
 ```bash
 # 1. 記事を作成・編集
-# src/content/blog/your-article.md
+# src/content/blog/2026/02/10/your-article/index.md
 
-# 2. ローカルで確認
+# 2. ローカルで確認（画像も自動コピーされます）
 npm run dev
 
 # 3. 変更をコミット

--- a/blog-template.md
+++ b/blog-template.md
@@ -9,6 +9,11 @@ description: "この記事の説明を1-2文で簡潔に書きます。検索結
 # 例: 2026-02-10T12:00:00（2026年2月10日 12時00分）
 pubDate: 2026-02-10T12:00:00
 
+# URLスラグ（必須）- 記事のURLを決定します
+# 記事フォルダ名と同じ値を設定してください
+# 例: フォルダが "my-article" なら slug: my-article
+slug: your-article-slug
+
 # 著者名（オプション）- デフォルトは "reiblast1123"
 author: reiblast1123
 
@@ -17,7 +22,8 @@ author: reiblast1123
 tags: ["タグ1", "タグ2", "タグ3"]
 
 # アイキャッチ画像（オプション）
-# image: "/images/post-cover.jpg"
+# 記事フォルダ内の画像を参照する場合:
+# image: "/images/blog/2026/02/10/your-article-slug/cover.png"
 
 # 下書きフラグ（オプション）- trueにすると非公開（ビルドから除外）
 draft: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@resvg/resvg-js": "^2.6.2",
+        "glob": "^11.0.0",
         "to-ico": "^1.1.5"
       }
     },
@@ -1183,6 +1184,39 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2637,6 +2671,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/crossws": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
@@ -3188,6 +3237,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3268,6 +3334,31 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
@@ -3674,12 +3765,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/jimp": {
       "version": "0.2.28",
@@ -5170,12 +5284,38 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.1",
@@ -5376,6 +5516,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
@@ -5455,6 +5602,33 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -6108,6 +6282,29 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shiki": {
       "version": "3.22.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.22.0.tgz",
@@ -6122,6 +6319,19 @@
         "@shikijs/types": "3.22.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/simple-swizzle": {
@@ -6951,6 +7161,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which-pm-runs": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "type": "module",
   "version": "1.0.0",
   "scripts": {
-    "dev": "astro dev",
-    "build": "astro build",
+    "copy-images": "node scripts/copy-blog-images.js",
+    "dev": "npm run copy-images && astro dev",
+    "build": "npm run copy-images && astro build",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -14,6 +15,7 @@
   },
   "devDependencies": {
     "@resvg/resvg-js": "^2.6.2",
+    "glob": "^11.0.0",
     "to-ico": "^1.1.5"
   }
 }

--- a/scripts/copy-blog-images.js
+++ b/scripts/copy-blog-images.js
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+import { glob } from 'glob';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const projectRoot = path.resolve(__dirname, '..');
+const contentDir = path.join(projectRoot, 'src', 'content', 'blog');
+const publicDir = path.join(projectRoot, 'public', 'images', 'blog');
+
+// 画像ファイルの拡張子
+const imageExts = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.avif'];
+
+console.log('Copying blog images...');
+console.log(`From: ${contentDir}`);
+console.log(`To: ${publicDir}`);
+
+// public/images/blog ディレクトリをクリーンアップ（既存の画像を削除）
+if (fs.existsSync(publicDir)) {
+  fs.rmSync(publicDir, { recursive: true });
+}
+fs.mkdirSync(publicDir, { recursive: true });
+
+// src/content/blog/**/* から画像を探す
+const files = await glob('**/*.*', { cwd: contentDir });
+
+let copiedCount = 0;
+
+for (const file of files) {
+  const ext = path.extname(file).toLowerCase();
+
+  // 画像ファイルのみ処理（.mdは除外）
+  if (!imageExts.includes(ext)) continue;
+
+  const sourcePath = path.join(contentDir, file);
+  const destPath = path.join(publicDir, file);
+
+  // ディレクトリを作成
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+
+  // コピー
+  fs.copyFileSync(sourcePath, destPath);
+  console.log(`✓ Copied: ${file}`);
+  copiedCount++;
+}
+
+console.log(`\nTotal: ${copiedCount} image(s) copied.`);

--- a/src/content/blog/2026/02/08/building-portfolio-with-astro/index.md
+++ b/src/content/blog/2026/02/08/building-portfolio-with-astro/index.md
@@ -4,6 +4,7 @@ description: "静的サイトジェネレーターAstroを使ってポートフ�
 pubDate: 2026-02-08T10:00:00
 author: reiblast1123
 tags: ["Astro", "Web開発", "ポートフォリオ"]
+slug: building-portfolio-with-astro
 ---
 
 # Astroでポートフォリオサイトを構築した話

--- a/src/content/blog/2026/02/10/welcome-to-my-blog/index.md
+++ b/src/content/blog/2026/02/10/welcome-to-my-blog/index.md
@@ -4,6 +4,7 @@ description: "reiblast1123のポートフォリオサイトにブログ機能を
 pubDate: 2026-02-10T00:00:00
 author: reiblast1123
 tags: ["お知らせ", "ブログ"]
+slug: welcome-to-my-blog
 ---
 
 # ブログを開設しました

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -11,6 +11,7 @@ const blog = defineCollection({
     tags: z.array(z.string()).default([]),
     image: z.string().optional(),
     draft: z.boolean().default(false),
+    slug: z.string().optional(),
   }),
 });
 


### PR DESCRIPTION
## 概要
ブログ記事を日付ベースのフォルダ構造で管理できるように改善しました。記事と画像を同じフォルダに配置できるようになり、より整理しやすくなります。

## 主な変更内容

### フォルダ構造の変更
- **Before:** `src/content/blog/article-name.md`
- **After:** `src/content/blog/2026/02/10/article-name/index.md`

### 画像対応
- 記事と同じフォルダ内に画像ファイルを配置可能
- ビルド時に `scripts/copy-blog-images.js` が自動実行され、画像を `public/images/blog/` にコピー
- `npm run dev` と `npm run build` の両方で自動実行されます

### クリーンなURL維持
- frontmatterに `slug` フィールドを追加
- URL: `/blog/article-name` （日付パスを含まない）
- フォルダ構造とURLを独立して管理

### ドキュメント更新
- **BLOG.md**: 新しいフォルダ構造、画像の扱い方を追記
- **blog-template.md**: `slug` フィールドを追加、画像パスの例を更新

## テスト結果
- ✅ `npm run build` 成功
- ✅ 既存の2記事を新構造に移行完了
- ✅ URLは変更なし（`/blog/welcome-to-my-blog`、`/blog/building-portfolio-with-astro`）

## 使用例

```bash
# 新しい記事の作成
mkdir -p "src/content/blog/2026/02/10/my-new-article"
cp blog-template.md "src/content/blog/2026/02/10/my-new-article/index.md"

# 画像を同じフォルダに配置
# src/content/blog/2026/02/10/my-new-article/
#   ├── index.md
#   ├── cover.png
#   └── screenshot.jpg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)