### PR TITLE
トップページにタブナビゲーションを追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -77,9 +77,14 @@ const comingSoonProjects = [
   <main>
     <!-- Hero Section -->
     <section class="hero">
-      <div class="hero-blob hero-blob-1" aria-hidden="true"></div>
-      <div class="hero-blob hero-blob-2" aria-hidden="true"></div>
-      <div class="hero-blob hero-blob-3" aria-hidden="true"></div>
+      <div class="hero-streak hero-streak-1" aria-hidden="true"></div>
+      <div class="hero-streak hero-streak-2" aria-hidden="true"></div>
+      <div class="hero-streak hero-streak-3" aria-hidden="true"></div>
+      <div class="hero-streak hero-streak-4" aria-hidden="true"></div>
+      <div class="hero-streak hero-streak-5" aria-hidden="true"></div>
+      <div class="hero-streak hero-streak-6" aria-hidden="true"></div>
+      <div class="hero-streak hero-streak-7" aria-hidden="true"></div>
+      <div class="hero-streak hero-streak-8" aria-hidden="true"></div>
       <div class="container">
         <h1 class="hero-title">reiblast1123</h1>
         <p class="hero-subtitle">Software Developer</p>
@@ -360,57 +365,62 @@ const comingSoonProjects = [
       }
     }
 
-    @keyframes blobFloat1 {
-      0%, 100% { transform: translate(0, 0) scale(1); }
-      33% { transform: translate(30px, -50px) scale(1.1); }
-      66% { transform: translate(-20px, 20px) scale(0.9); }
+    @keyframes streakLTR {
+      from { transform: translateX(-110%); }
+      to   { transform: translateX(110vw); }
     }
 
-    @keyframes blobFloat2 {
-      0%, 100% { transform: translate(0, 0) scale(1); }
-      33% { transform: translate(-40px, 30px) scale(0.9); }
-      66% { transform: translate(20px, -30px) scale(1.1); }
-    }
-
-    @keyframes blobFloat3 {
-      0%, 100% { transform: translate(0, 0) scale(1); }
-      50% { transform: translate(20px, 40px) scale(1.05); }
-    }
-
-    .hero-blob {
+    .hero-streak {
       position: absolute;
-      border-radius: 50%;
-      filter: blur(40px);
-      opacity: 0.5;
+      left: 0;
+      border-radius: 999px;
       pointer-events: none;
       z-index: 0;
+      animation: streakLTR linear infinite;
     }
 
-    .hero-blob-1 {
-      width: 350px;
-      height: 350px;
-      background: rgba(255, 255, 255, 0.55);
-      top: -120px;
-      left: -80px;
-      animation: blobFloat1 14s ease-in-out infinite;
+    /* ヘッドライト（白〜温白色） */
+    .hero-streak-1 {
+      width: 220px; height: 2px; top: 10%;
+      background: linear-gradient(to right, transparent, rgba(255, 248, 200, 1), transparent);
+      animation-duration: 2.6s; animation-delay: 0s;
+    }
+    .hero-streak-2 {
+      width: 320px; height: 1px; top: 28%;
+      background: linear-gradient(to right, transparent, rgba(255, 255, 255, 0.95), transparent);
+      animation-duration: 3.4s; animation-delay: -1.5s;
+    }
+    .hero-streak-3 {
+      width: 170px; height: 2px; top: 50%;
+      background: linear-gradient(to right, transparent, rgba(255, 240, 150, 0.9), transparent);
+      animation-duration: 2.1s; animation-delay: -0.7s;
+    }
+    .hero-streak-4 {
+      width: 260px; height: 1px; top: 72%;
+      background: linear-gradient(to right, transparent, rgba(255, 255, 255, 0.9), transparent);
+      animation-duration: 3.9s; animation-delay: -2.3s;
     }
 
-    .hero-blob-2 {
-      width: 250px;
-      height: 250px;
-      background: rgba(255, 140, 200, 0.6);
-      bottom: -80px;
-      right: 5%;
-      animation: blobFloat2 18s ease-in-out infinite;
+    /* テールライト（赤〜オレンジ） */
+    .hero-streak-5 {
+      width: 200px; height: 2px; top: 18%;
+      background: linear-gradient(to right, transparent, rgba(255, 70, 50, 0.9), transparent);
+      animation-duration: 3.1s; animation-delay: -0.9s;
     }
-
-    .hero-blob-3 {
-      width: 180px;
-      height: 180px;
-      background: rgba(130, 220, 255, 0.6);
-      top: 40%;
-      right: 15%;
-      animation: blobFloat3 11s ease-in-out infinite;
+    .hero-streak-6 {
+      width: 140px; height: 1px; top: 40%;
+      background: linear-gradient(to right, transparent, rgba(255, 100, 60, 0.85), transparent);
+      animation-duration: 2.4s; animation-delay: -0.3s;
+    }
+    .hero-streak-7 {
+      width: 290px; height: 2px; top: 62%;
+      background: linear-gradient(to right, transparent, rgba(255, 60, 40, 0.9), transparent);
+      animation-duration: 4.1s; animation-delay: -2.9s;
+    }
+    .hero-streak-8 {
+      width: 180px; height: 1px; top: 85%;
+      background: linear-gradient(to right, transparent, rgba(255, 110, 70, 0.85), transparent);
+      animation-duration: 2.9s; animation-delay: -1.6s;
     }
 
     /* Tab Navigation */


### PR DESCRIPTION
## Summary
- タブ構成: Top / 愛車管理アプリ - Shakeeper / 赤ちゃん記録アプリ - MilPon / Other Projects / Blog
- Shakeeper・MilPon タブは公式サイトを iframe で遅延読み込みして表示
- タブ状態をURLハッシュに保存（`#shakeeper` 等で直リンク可能）
- タブナビはスクロール時にスティッキー表示

## Notes
- iframe での埋め込みは対象サイトが `X-Frame-Options` でブロックしていると表示されないため、Shakeeper・MilPon 側のヘッダー設定も確認が必要

## Test plan
- [ ] 各タブ切り替えが正常に動作する
- [ ] Shakeeper・MilPon の iframe が表示される（要確認）
- [ ] URLハッシュによるタブ復元が動作する
- [ ] モバイルでタブが横スクロールできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)