### PR TITLE
Charinプロジェクトをポートフォリオに追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,7 +52,7 @@ const mainProjects = [
   },
   {
     id: 'charin',
-    name: 'Charin',
+    name: 'Charin（チャリン）',
     description: 'AIの独自分析で売買タイミングをお知らせ - FX AI分析ツール',
     longDescription: 'AIを活用した外国為替（FX）取引支援ツール。ドル円の値動きをリアルタイムで確認しながら、AIが「買い・売り・様子見」を日本語で教えてくれます。完全無料・登録不要でPC・スマホどちらでも利用可能。',
     tech: ['Next.js', 'TypeScript', 'AI'],


### PR DESCRIPTION
## Summary
- FX AI分析ツール「Charin」をShakeeper・milponと同様にタブ付きで追加
- `mainProjects` 配列にCharinのデータ（説明・機能・技術スタック）を追加
- タブナビゲーションに「FX AI分析ツール - Charin」ボタンを追加
- iframeで https://charin.reiblast.f5.si を埋め込むタブパネルを追加
- GitHubリポジトリがプライベートのため、プロジェクトカードのGitHubボタンを条件付きレンダリング（`project.github`がnullの場合は非表示）に変更

## Test plan
- [ ] ビルド成功確認 (`npm run build`) ✅
- [ ] タブ「FX AI分析ツール - Charin」をクリックしてiframeが表示されること
- [ ] Other Projectsタブにてcharinのプロジェクトカードが表示されること
- [ ] Shakeeper・milponのGitHubボタンが引き続き表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)