### PR TITLE
feat: 新記事push時にXへ自動ポストするGitHub Actionsを追加

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "post-to-x-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "twitter-api-v2": "^1.18.0"
+  }
+}

--- a/.github/scripts/post-to-x.js
+++ b/.github/scripts/post-to-x.js
@@ -1,0 +1,81 @@
+const { TwitterApi } = require('twitter-api-v2');
+const fs = require('fs');
+const path = require('path');
+
+const client = new TwitterApi({
+  appKey: process.env.X_API_KEY,
+  appSecret: process.env.X_API_SECRET,
+  accessToken: process.env.X_ACCESS_TOKEN,
+  accessSecret: process.env.X_ACCESS_TOKEN_SECRET,
+});
+
+const postFile = process.env.POST_FILE;
+if (!postFile) {
+  console.error('POST_FILE environment variable is not set');
+  process.exit(1);
+}
+
+// Read blog post file (path is relative to repo root)
+const repoRoot = path.join(__dirname, '..', '..');
+const fullPath = path.join(repoRoot, postFile);
+const content = fs.readFileSync(fullPath, 'utf-8');
+
+// Parse frontmatter
+const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+if (!frontmatterMatch) {
+  console.log('No frontmatter found, skipping');
+  process.exit(0);
+}
+
+const frontmatter = frontmatterMatch[1];
+
+// Extract fields
+const titleMatch = frontmatter.match(/^title:\s*["'](.+?)["']\s*$/m)
+  || frontmatter.match(/^title:\s*(.+?)\s*$/m);
+const slugMatch = frontmatter.match(/^slug:\s*(.+?)\s*$/m);
+const draftMatch = frontmatter.match(/^draft:\s*(.+?)\s*$/m);
+const tagsMatch = frontmatter.match(/^tags:\s*\[([^\]]*)\]/m);
+
+if (!titleMatch || !slugMatch) {
+  console.error('Missing required frontmatter fields (title or slug)');
+  process.exit(1);
+}
+
+const title = titleMatch[1];
+const slug = slugMatch[1];
+const draft = draftMatch ? draftMatch[1].trim() === 'true' : false;
+
+if (draft) {
+  console.log('Post is a draft, skipping');
+  process.exit(0);
+}
+
+// Build hashtags from article tags (up to 3)
+let hashtags = '#エンジニア #ブログ';
+if (tagsMatch) {
+  const tags = tagsMatch[1]
+    .split(',')
+    .map(t => t.trim().replace(/["']/g, ''))
+    .filter(t => t.length > 0)
+    .slice(0, 3)
+    .map(t => `#${t.replace(/\s+/g, '')}`)
+    .join(' ');
+  if (tags) hashtags = tags;
+}
+
+const url = `https://reiblast.f5.si/blog/${slug}`;
+const text = `📝 新記事を公開しました！\n\n「${title}」\n\n${url}\n\n${hashtags}`;
+
+async function main() {
+  console.log('Posting to X...');
+  console.log('Text:', text);
+  try {
+    const tweet = await client.v2.tweet(text);
+    console.log('Posted successfully! Tweet ID:', tweet.data.id);
+  } catch (err) {
+    console.error('Failed to post to X:', err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/.github/workflows/post-to-x.yml
+++ b/.github/workflows/post-to-x.yml
@@ -1,0 +1,47 @@
+name: Post to X on new blog post
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/content/blog/**/*.md'
+
+jobs:
+  post-to-x:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Find new blog posts
+        id: find-post
+        run: |
+          NEW_POST=$(git diff --name-only --diff-filter=A HEAD~1 HEAD | grep 'src/content/blog/.*\.md$' | head -1)
+          if [ -z "$NEW_POST" ]; then
+            echo "No new blog post found"
+            echo "has_post=false" >> $GITHUB_OUTPUT
+          else
+            echo "Found new post: $NEW_POST"
+            echo "has_post=true" >> $GITHUB_OUTPUT
+            echo "post_file=$NEW_POST" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.find-post.outputs.has_post == 'true'
+        with:
+          node-version: '20'
+
+      - name: Post to X
+        if: steps.find-post.outputs.has_post == 'true'
+        run: |
+          cd .github/scripts
+          npm install
+          node post-to-x.js
+        env:
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          POST_FILE: ${{ steps.find-post.outputs.post_file }}


### PR DESCRIPTION
## Summary
- `master` ブランチに新しいブログ記事（`.md`）が追加されたとき、自動でXにポストするGitHub Actionsを追加
- frontmatterから `title`, `slug`, `tags`, `draft` を読み取り、ポスト内容を生成
- `draft: true` の記事はスキップ
- 記事のタグをそのままハッシュタグとして使用

## Test plan
- [ ] GitHub Secrets に `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` が登録済みであること
- [ ] 次回ブログ記事を master にpushしたとき、Actions が起動してXにポストされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)