### PR TITLE
fix: pages.dev アクセス時に noindex を自動付与（重複コンテンツ対策）

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,6 +13,7 @@ const { title, description = 'reiblast1123 のプロジェクトポートフォ�
 const adsenseClientId = import.meta.env.PUBLIC_ADSENSE_CLIENT_ID;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImageURL = ogImage ? new URL(ogImage, Astro.site).toString() : new URL('/icon-512x512.png', Astro.site).toString();
+const isProduction = Astro.url.origin === Astro.site?.origin;
 
 const websiteJsonLd = {
   '@context': 'https://schema.org',
@@ -31,6 +32,7 @@ const websiteJsonLd = {
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
     <link rel="canonical" href={canonicalURL} />
+    {!isProduction && <meta name="robots" content="noindex" />}
 
     <!-- OGP -->
     <meta property="og:type" content="website" />


### PR DESCRIPTION
## 概要

Google Search Console で「重複しています。ユーザーにより、正規ページとして選択されていません」エラーが発生していた原因を修正。

## 問題

Cloudflare Pages では本番URL（`reiblast.f5.si`）とは別に `reiblast-f5-si.pages.dev` でも同じコンテンツにアクセスできる。Google がこの `pages.dev` URL をクロールし、同一コンテンツの重複として扱っていた。

## 対応内容

`Layout.astro` に以下のロジックを追加：

- `Astro.url.origin === Astro.site.origin`（本番ドメイン）→ noindex なし（従来通り）
- それ以外（`pages.dev` やブランチプレビュー URL）→ `<meta name="robots" content="noindex">` を自動出力

## 動作確認

- `npm run build` でビルド成功を確認
- 本番ビルドの HTML に `noindex` が含まれないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)