### PR TITLE
feat: ブログ記事一覧にタグフィルター機能を追加

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -9,6 +9,9 @@ const allPosts = await getCollection('blog', ({ data }) => {
 // 日付でソート（新しい順）
 const sortedPosts = allPosts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
+// ユニークタグ一覧
+const allTags = [...new Set(sortedPosts.flatMap(p => p.data.tags ?? []))];
+
 function formatDate(date: Date): string {
   return new Intl.DateTimeFormat('ja-JP', {
     year: 'numeric',
@@ -92,9 +95,16 @@ function formatDate(date: Date): string {
         {sortedPosts.length === 0 ? (
           <p class="no-posts">まだ記事がありません。</p>
         ) : (
+          <>
+            <div class="tag-filter">
+              <button class="filter-btn active" data-tag="all">すべて</button>
+              {allTags.map(tag => (
+                <button class="filter-btn" data-tag={tag}>{tag}</button>
+              ))}
+            </div>
           <div class="posts-grid">
             {sortedPosts.map((post) => (
-              <article class="post-card">
+              <article class="post-card" data-tags={post.data.tags?.join(',') ?? ''}>
                 <a href={`/blog/${post.slug}`} class="post-link">
                   <div class="post-header">
                     <time class="post-date" datetime={post.data.pubDate.toISOString()}>
@@ -117,6 +127,7 @@ function formatDate(date: Date): string {
               </article>
             ))}
           </div>
+          </>
         )}
       </div>
     </section>
@@ -286,6 +297,36 @@ function formatDate(date: Date): string {
       color: var(--primary-dark);
     }
 
+    .tag-filter {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 2rem;
+    }
+
+    .filter-btn {
+      padding: 0.375rem 0.875rem;
+      border: 2px solid var(--border);
+      border-radius: 2rem;
+      background: transparent;
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s, background 0.15s;
+    }
+
+    .filter-btn:hover {
+      border-color: #111111;
+      color: #111111;
+    }
+
+    .filter-btn.active {
+      background: #111111;
+      border-color: #111111;
+      color: #FFD700;
+    }
+
     @media (max-width: 768px) {
       .blog-title {
         font-size: 2rem;
@@ -296,4 +337,18 @@ function formatDate(date: Date): string {
       }
     }
   </style>
+
+  <script>
+    document.querySelectorAll<HTMLButtonElement>('.filter-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tag = btn.dataset.tag;
+        document.querySelectorAll<HTMLButtonElement>('.filter-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        document.querySelectorAll<HTMLElement>('.post-card').forEach(card => {
+          const tags = card.dataset.tags ? card.dataset.tags.split(',') : [];
+          card.style.display = (tag === 'all' || tags.includes(tag!)) ? '' : 'none';
+        });
+      });
+    });
+  </script>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ const { Content: ProfileContent } = await profileEntry.render();
 
 const allPosts = await getCollection('blog', ({ data }) => data.draft !== true);
 const sortedPosts = allPosts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+const allTags = [...new Set(sortedPosts.flatMap(p => p.data.tags ?? []))];
 
 function formatDate(date: Date): string {
   return new Intl.DateTimeFormat('ja-JP', {
@@ -431,9 +432,16 @@ const comingSoonProjects = [
           {sortedPosts.length === 0 ? (
             <p class="no-posts">まだ記事がありません。</p>
           ) : (
+            <>
+              <div class="blog-tag-filter">
+                <button class="blog-filter-btn active" data-tag="all">すべて</button>
+                {allTags.map(tag => (
+                  <button class="blog-filter-btn" data-tag={tag}>{tag}</button>
+                ))}
+              </div>
             <div class="blog-grid">
               {sortedPosts.map((post) => (
-                <article class="blog-card">
+                <article class="blog-card" data-tags={post.data.tags?.join(',') ?? ''}>
                   <a href={`/blog/${post.slug}`} class="blog-link">
                     <div class="blog-card-header">
                       <time class="blog-date" datetime={post.data.pubDate.toISOString()}>
@@ -454,6 +462,7 @@ const comingSoonProjects = [
                 </article>
               ))}
             </div>
+            </>
           )}
         </div>
       </div>
@@ -509,6 +518,19 @@ const comingSoonProjects = [
     if (hash && document.getElementById(`tab-${hash}`)) {
       activateTab(hash);
     }
+
+    // Blog tab tag filter
+    document.querySelectorAll<HTMLButtonElement>('.blog-filter-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tag = btn.dataset.tag;
+        document.querySelectorAll<HTMLButtonElement>('.blog-filter-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        document.querySelectorAll<HTMLElement>('#tab-blog .blog-card').forEach(card => {
+          const tags = card.dataset.tags ? card.dataset.tags.split(',') : [];
+          card.style.display = (tag === 'all' || tags.includes(tag!)) ? '' : 'none';
+        });
+      });
+    });
   </script>
 
   <style>
@@ -1078,6 +1100,36 @@ const comingSoonProjects = [
       font-weight: 600;
       color: var(--primary);
       margin-top: auto;
+    }
+
+    .blog-tag-filter {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .blog-filter-btn {
+      padding: 0.375rem 0.875rem;
+      border: 2px solid var(--border);
+      border-radius: 2rem;
+      background: transparent;
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s, background 0.15s;
+    }
+
+    .blog-filter-btn:hover {
+      border-color: #111111;
+      color: #111111;
+    }
+
+    .blog-filter-btn.active {
+      background: #111111;
+      border-color: #111111;
+      color: #FFD700;
     }
 
     /* Profile Tab */


### PR DESCRIPTION
## Summary

- `/blog` ページとトップページのブログタブ両方にタグフィルターを実装
- タグボタンをクリックすると即時絞り込み（ページ遷移なし）
- 「すべて」ボタンで全件表示に戻る
- アクティブタグは黒背景・Racing Yellow 文字でハイライト

## Changes

- `src/pages/blog/index.astro` - フィルターUI・data-tags属性・CSS・script追加
- `src/pages/index.astro` - ブログタブ内に同様のフィルター追加（クラス名は `.blog-filter-btn` で分離）

## Test plan

- [ ] `/blog` でタグボタンをクリックして絞り込み動作確認
- [ ] 「すべて」ボタンで全件表示に戻ることを確認
- [ ] トップページのブログタブでも同様に動作することを確認
- [ ] モバイルでボタンが折り返し表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)