### PR TITLE
fix: ブログ一覧ページの meta description を修正

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -23,7 +23,10 @@ function formatDate(date: Date): string {
 }
 ---
 
-<Layout title="沖縄でエンジニアしてて思ったこと。 - reiblast1123">
+<Layout
+  title="沖縄でエンジニアしてて思ったこと。 - reiblast1123"
+  description="インフラエンジニアの24歳男子が仕事、趣味、クルマ、社会に対して思ったことを書いてくとこ。新入社員が「なるほど、わからん」なところをゆるく解説します。"
+>
   <main>
     <!-- Hero Section -->
     <section class="blog-hero">


### PR DESCRIPTION
## Summary

- ブログ一覧ページの `description` prop が未設定でデフォルト値が使われていたのを修正
- Google 検索結果のスニペットにブログのコンセプトが表示されるようになる

## Note

Google に「Blog - reiblast1123」という古いタイトルがキャッシュされているが、
コード上のタイトルはすでに「沖縄でエンジニアしてて思ったこと。 - reiblast1123」に更新済み。
Google が再クロールすれば自動的に更新される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)