### PR TITLE
fix: OGP画像URLのslug undefined と日付ずれを修正

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -19,8 +19,8 @@ const { Content, headings } = await post.render();
 
 // OGP画像: src/content/blog/YYYY/MM/DD/<slug>/ogp.png → コピー先 /images/blog/YYYY/MM/DD/<slug>/ogp.png
 const _d = post.data.pubDate;
-const _datePath = `${_d.getFullYear()}/${String(_d.getMonth()+1).padStart(2,'0')}/${String(_d.getDate()).padStart(2,'0')}`;
-const ogImage = `/images/blog/${_datePath}/${post.data.slug}/ogp.png`;
+const _datePath = `${_d.getUTCFullYear()}/${String(_d.getUTCMonth()+1).padStart(2,'0')}/${String(_d.getUTCDate()).padStart(2,'0')}`;
+const ogImage = `/images/blog/${_datePath}/${post.slug}/ogp.png`;
 
 // Google AdSense
 // 環境変数 PUBLIC_ADSENSE_CLIENT_ID と PUBLIC_ADSENSE_SLOT_ARTICLE が設定されていると広告が表示されます


### PR DESCRIPTION
## 問題

- `og:image` が `/images/blog/2026/02/22/undefined/ogp.png` になっていた

## 原因と修正

1. **slug が undefined**: Astro では `slug` は予約フィールドのため `post.data.slug` が `undefined` になる → `post.slug` を使用
2. **日付が1日ずれる**: js-yaml が `2026-02-22T19:00:00` をUTCとして解釈するため、JST(UTC+9)で `getDate()` すると翌日になる → `getUTCDate()` を使用

## 結果

`https://reiblast.f5.si/images/blog/2026/02/22/24sai-kara-mita-chatgpt-no-sekai/ogp.png` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)