### PR TITLE
fix: トップページの楽天広告サイドバー表示修正

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1286,7 +1286,7 @@ const comingSoonProjects = [
       gap: 0.2rem;
     }
 
-    @media (max-width: 1400px) {
+    @media (max-width: 1024px) {
       .blog-ad-side {
         display: none !important;
       }


### PR DESCRIPTION
## Summary
- `max-width: 1400px` で非表示にしていたため、ほぼ全環境でサイドバー広告が表示されていなかった
- `max-width: 1024px` に変更し、デスクトップ環境で広告が表示されるよう修正

## Test plan
- [ ] 1024px 以上の画面幅でトップページのブログセクションに楽天広告サイドバーが表示されること
- [ ] 1024px 未満（モバイル・タブレット）では非表示のままであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)