### PR TITLE
fix: ブログ一覧パンくずの「Blog」を正式タイトルに変更

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -94,7 +94,7 @@ function formatDate(date: Date): string {
         <nav class="breadcrumb" aria-label="パンくずリスト">
           <a href="/">ホーム</a>
           <span class="sep" aria-hidden="true">/</span>
-          <span class="current" aria-current="page">Blog</span>
+          <span class="current" aria-current="page">沖縄でエンジニアしてて思ったこと。</span>
         </nav>
         {sortedPosts.length === 0 ? (
           <p class="no-posts">まだ記事がありません。</p>


### PR DESCRIPTION
## Summary
- ブログ一覧ページのパンくずリスト「Blog」を「沖縄でエンジニアしてて思ったこと。」に変更
- GoogleがパンくずのテキストをSERPのタイトルに使っていた問題の対策

## Test plan
- [x] `npm run build` 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)