### PR TITLE
feat: ドメインを reiblast.f5.si → reiblast1123.com に移行

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,7 +10,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // https://astro.build/config
 export default defineConfig({
   output: 'static',
-  site: 'https://reiblast.f5.si',
+  site: 'https://reiblast1123.com',
   integrations: [mdx(), sitemap()],
   markdown: {
     shikiConfig: {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://reiblast.f5.si/sitemap-index.xml
+Sitemap: https://reiblast1123.com/sitemap-index.xml

--- a/scripts/generate-ogp.js
+++ b/scripts/generate-ogp.js
@@ -203,7 +203,7 @@ function buildOgpSvg(title) {
     font-size="22"
     fill="rgba(0,0,0,0.45)"
     text-anchor="end"
-  >reiblast.f5.si</text>
+  >reiblast1123.com</text>
 </svg>`;
 }
 

--- a/scripts/test-ogp.js
+++ b/scripts/test-ogp.js
@@ -137,7 +137,7 @@ function buildOgpSvg(title) {
     font-size="22"
     fill="rgba(0,0,0,0.45)"
     text-anchor="end"
-  >reiblast.f5.si</text>
+  >reiblast1123.com</text>
 </svg>`;
 }
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -18,7 +18,7 @@ import Layout from '../layouts/Layout.astro';
         <div class="terminal-body">
           <p class="terminal-line">
             <span class="prompt">r&gt;_</span>
-            <span class="command"> curl https://reiblast.f5.si<span class="cursor-path">{Astro.url.pathname}</span></span>
+            <span class="command"> curl https://reiblast1123.com<span class="cursor-path">{Astro.url.pathname}</span></span>
           </p>
           <p class="terminal-line output error-output">
             <span class="error-code">404</span> Not Found

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -21,8 +21,8 @@ const lastUpdated = '2026年3月25日';
         <p class="last-updated">最終更新日：{lastUpdated}</p>
 
         <p>
-          reiblast1123（以下「当サイト」）は、<strong>https://reiblast.f5.si</strong> および
-          <strong>*.reiblast.f5.si</strong> のすべてのサブドメインにおけるプライバシーの保護を重要と考えています。
+          reiblast1123（以下「当サイト」）は、<strong>https://reiblast1123.com</strong> および
+          <strong>*.reiblast1123.com</strong> のすべてのサブドメインにおけるプライバシーの保護を重要と考えています。
           本プライバシーポリシーは、当サイトが収集する情報とその利用方法についてご説明するものです。
         </p>
 
@@ -35,7 +35,7 @@ const lastUpdated = '2026年3月25日';
             </tr>
             <tr>
               <th>ウェブサイト</th>
-              <td>https://reiblast.f5.si</td>
+              <td>https://reiblast1123.com</td>
             </tr>
             <tr>
               <th>お問い合わせ</th>
@@ -100,7 +100,7 @@ const lastUpdated = '2026年3月25日';
             Cookie を使用する場合があります。Cookie の使用を望まない場合は、ブラウザの設定で無効にすることが可能です。
           </p>
           <p>
-            なお、当サイトのすべてのサブドメイン（shakeeper.reiblast.f5.si、milpon.reiblast.f5.si 等）においても、
+            なお、当サイトのすべてのサブドメイン（shakeeper.reiblast1123.com、milpon.reiblast1123.com 等）においても、
             同様に楽天アフィリエイトによる広告を掲載する場合があります。
           </p>
         </section>

--- a/tools/blog-editor/templates/editor.html
+++ b/tools/blog-editor/templates/editor.html
@@ -1105,7 +1105,7 @@ ${desc}
 function getTweetUrl() {
   const slug = document.getElementById('fm-slug').value.trim();
   if (!slug) return null;
-  return `https://reiblast.f5.si/blog/${slug}/`;
+  return `https://reiblast1123.com/blog/${slug}/`;
 }
 
 /** エディタ本文の冒頭1行（見出し要素を除いた最初の段落テキスト）を返す */
@@ -1120,7 +1120,7 @@ function getFirstLine() {
 
 function buildTweetTemplates() {
   const title    = document.getElementById('fm-title').value.trim() || '（タイトル未入力）';
-  const url      = getTweetUrl() || 'https://reiblast.f5.si/blog/...';
+  const url      = getTweetUrl() || 'https://reiblast1123.com/blog/...';
   const tagsRaw  = document.getElementById('fm-tags').value;
   const hashTags = tagsRaw
     .split(',')

--- a/tweet-template.md
+++ b/tweet-template.md
@@ -14,7 +14,7 @@
 
 〈一言で内容を説明〉
 
-🔗 https://reiblast.f5.si/blog/YYYY/MM/DD/slug/
+🔗 https://reiblast1123.com/blog/YYYY/MM/DD/slug/
 
 #エンジニアブログ #インフラエンジニア #タグ
 ```
@@ -31,7 +31,7 @@
 〈検証・調査した内容を一言で〉
 同じ状況で詰まってる人の参考になれば！
 
-🔗 https://reiblast.f5.si/blog/YYYY/MM/DD/slug/
+🔗 https://reiblast1123.com/blog/YYYY/MM/DD/slug/
 
 #インフラエンジニア #エンジニアブログ #タグ
 ```
@@ -48,7 +48,7 @@
 〈内容をカジュアルに一言〉
 よかったら読んでみてください(^o^)
 
-🔗 https://reiblast.f5.si/blog/YYYY/MM/DD/slug/
+🔗 https://reiblast1123.com/blog/YYYY/MM/DD/slug/
 
 #タグ #タグ
 ```
@@ -65,7 +65,7 @@
 〈当時の状況・内容を一言〉
 黒歴史感あるけどせっかくなので笑
 
-🔗 https://reiblast.f5.si/blog/YYYY/MM/DD/slug/
+🔗 https://reiblast1123.com/blog/YYYY/MM/DD/slug/
 
 #エンジニアブログ #タグ
 ```


### PR DESCRIPTION
## Summary
- `astro.config.mjs` の site URL を `https://reiblast1123.com` に変更
- `robots.txt` の Sitemap URL を更新
- OGP生成スクリプトのドメイン表記を更新
- 404ページ、プライバシーポリシー、blog-editor、ツイートテンプレートのURL を更新
- サブドメイン（shakeeper/milpon/charin）はアプリ移行まで旧ドメインのまま

## Test plan
- [x] `npm run build` 成功確認済み
- [x] Cloudflare Pages にカスタムドメイン追加済み
- [x] Search Console に新ドメイン追加・サイトマップ送信済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)