### PR TITLE
fix: お買い物マラソン情報を4/14〜4/17に更新

### DIFF
--- a/src/content/blog/2026/04/08/ugreen-100w-charger-review/index.mdx
+++ b/src/content/blog/2026/04/08/ugreen-100w-charger-review/index.mdx
@@ -2,7 +2,7 @@
 title: "カフェ勢必見！UGREEN 100W 巻き取り式充電器を買ったら神アイテムだった件"
 description: "カフェでのノートPC＋スマホ同時充電に悩んでいたら、UGREEN の 100W 巻き取り式充電器が解決してくれた話。CF-SZ6 + PDトリガーアダプター構成でも快適に使えるか実際に試してみました。"
 pubDate: 2026-04-08T12:30:00
-updatedDate: 2026-04-08T22:00:00
+updatedDate: 2026-04-12T12:00:00
 slug: ugreen-100w-charger-review
 author: reiblast1123
 tags: ["ガジェット", "充電器", "UGREEN", "レビュー", "カフェ"]
@@ -42,10 +42,8 @@ export const pocoX7ProHtmlMobile = `<table border="0" cellpadding="0" cellspacin
 
 ちなみに **UGREEN（ユーグリーン）** は中国発のガジェット・充電器ブランドで、AmazonやECサイトでも評価が高くてコスパに定評があります。僕も以前からケーブルとかを何本か使っていて、品質に対する信頼感はありました。
 
-<Note type="warning" title="🛒 楽天お買い物マラソン開催中！4/10(金) 01:59まで">
-複数ショップで買い回るほどポイント最大10倍（上限7,000pt）。**期限間近！** 他にも欲しいものがある人はこの機会にまとめて買うとお得です。
-
-また、UGREENのこの充電器は**4/10まで38%OFFクーポン配布中**。定価から大幅値引きのタイミングを逃すな！
+<Note type="warning" title="🛒 楽天お買い物マラソン 4/14(火) 20:00〜4/17(金) 09:59">
+複数ショップで買い回るほどポイント最大11倍！他にも欲しいものがある人はこの機会にまとめて買うとお得です。エントリーは4/12(日) 10:00から受付中！
 </Note>
 
 ## 買った理由
@@ -60,7 +58,7 @@ export const pocoX7ProHtmlMobile = `<table border="0" cellpadding="0" cellspacin
 
 <RakutenAffiliate html={pocoX7ProHtml} htmlMobile={pocoX7ProHtmlMobile} />
 
-なお、POCO X7 Proも4/10まで**7,380円OFFクーポン**があるので、スマホごと乗り換えを考えている人はこの機会に。
+なお、POCO X7 Proもスマホごと乗り換えを考えている人はチェックしてみてください。
 
 この2台を1個の充電器でまとめて充電したい、かつ持ち運びでかさばらないコンパクトなやつが欲しい…ということで条件を整理すると：
 
@@ -162,12 +160,8 @@ CF-SZ6 + PDトリガーアダプターという、ちょっと変わった構成
 
 <RakutenAffiliate html={ugreenChargerHtml} htmlMobile={ugreenChargerHtmlMobile} />
 
-<Note type="warning" title="🛒 お買い物マラソン＆クーポンは4/10(金) 01:59まで！">
-- UGREEN 100W 巻き取り式充電器：**38%OFFクーポン配布中**
-- POCO X7 Pro：**7,380円OFFクーポン配布中**
-- お買い物マラソンでポイント最大10倍（上限7,000pt）
-
-**期限間近！** 迷ってる人は今すぐどうぞ。
+<Note type="warning" title="🛒 楽天お買い物マラソン 4/14(火) 20:00〜4/17(金) 09:59">
+複数ショップで買い回るほどポイント最大11倍！まとめ買いするならこのタイミングがお得です。エントリーは4/12(日) 10:00から受付中！
 </Note>
 
 ではまた次回！最近いろいろガジェットやらジャンク品やら揃えているので、そのうち書けたらなと思ってます。それではー(^o^)


### PR DESCRIPTION
## Summary
- お買い物マラソン情報を4/10終了分から4/14〜4/17開催分に更新
- 期限切れのクーポン情報（UGREEN 38%OFF / POCO 7,380円OFF）を削除
- updatedDateを2026-04-12に更新

## Test plan
- [x] `npm run build` 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)