### PR TITLE
fix: ブログ内部リンクの trailing slash を統一

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   output: 'static',
   site: 'https://reiblast1123.com',
+  trailingSlash: 'always',
   integrations: [mdx(), sitemap()],
   markdown: {
     shikiConfig: {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -123,7 +123,7 @@ function formatDate(date: Date): string {
               <div class="posts-grid">
                 {sortedPosts.map((post) => (
                   <article class="post-card" data-tags={post.data.tags?.join(',') ?? ''}>
-                    <a href={`/blog/${post.slug}`} class="post-link">
+                    <a href={`/blog/${post.slug}/`} class="post-link">
                       <div class="post-header">
                         <time class="post-date" datetime={post.data.pubDate.toISOString()}>
                           {formatDate(post.data.pubDate)}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -343,7 +343,7 @@ const comingSoonProjects = [
               <div class="blog-grid">
                 {recentPosts.map((post) => (
                   <article class="blog-card">
-                    <a href={`/blog/${post.slug}`} class="blog-link">
+                    <a href={`/blog/${post.slug}/`} class="blog-link">
                       <div class="blog-card-header">
                         <time class="blog-date" datetime={post.data.pubDate.toISOString()}>
                           {formatDate(post.data.pubDate)}


### PR DESCRIPTION
## Summary

Search Console から「ページにリダイレクトがあります」「リダイレクト エラー」の通知が届いていた件への対応。

Cloudflare Pages は `/blog/foo` → `/blog/foo/` を 308 で自動リダイレクトするが、サイト内の記事リンクが末尾スラッシュなしで生成されていたため、クリック毎に 308 が挟まる状態だった。

## Changes

- [src/pages/blog/index.astro](src/pages/blog/index.astro) / [src/pages/index.astro](src/pages/index.astro): 記事カードの `href` を \`/blog/\${slug}\` → \`/blog/\${slug}/\`
- [astro.config.mjs](astro.config.mjs): \`trailingSlash: 'always'\` を追加（以降の一貫性担保）

## Test plan

- [x] `npm run build` 成功
- [x] 生成HTMLの内部リンクが全て末尾スラッシュ付き
- [x] sitemap-0.xml 全URL末尾スラッシュ付き
- [ ] マージ後、Cloudflare Pages デプロイ完了を確認
- [ ] Search Console でインデックス登録の再リクエスト

## 本PRで扱わないもの

- **代替ページ（適切な canonical タグあり）** / `https://reiblast1123.com/`  
  canonical タグは正しく設定済み。Google 側の認識ラグの可能性が高く、放置で自然解消する類
- **インデックス未登録（16件）**  
  エラーではなく「未登録」状態。本修正で内部リンク評価が改善すれば間接的に解消を期待

🤖 Generated with [Claude Code](https://claude.com/claude-code)