### PR TITLE
feat: blog-editor を TipTap に移行 + Keystatic CMS PoC

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -88,7 +88,7 @@ WantedBy=default.target
 | 文字色・背景色 | 上部のカラードット（よく使う色をプリセット済み） |
 | 記事一覧・編集・削除 | ヘッダーの「📂 記事一覧」 |
 | .md / .mdx 切り替え | 右上のトグル |
-| MDXコンポーネント挿入 | .mdx モード時に表示されるプリセットボタン |
+| MDXコンポーネント挿入 | ツールバーの 📝⚠💡🚨🔖📂 ボタン（自動で .mdx に切り替わる） |
 | 保存 | 「保存」ボタン または `Ctrl+S` |
 | Markdownプレビュー | 「更新 ↻」で右ペインに表示 |
 
@@ -96,15 +96,15 @@ WantedBy=default.target
 
 ```bash
 # 1. エディタで記事を書いて「保存」
-#    → src/content/blog/YYYY/MM/DD/<slug>/index.md に自動保存される
+#    → src/content/blog/YYYY/MM/DD/<slug>/index.md に自動保存
+#    → post/<slug> ブランチが自動作成され、コミットまで完了
 
 # 2. ビルド確認
 npm run build
 
-# 3. コミット & プッシュ → Cloudflare Pages が自動デプロイ
-git add src/content/blog/
-git commit -m "Add new blog post: 記事タイトル"
-git push origin main
+# 3. プッシュ → PR → マージ → Cloudflare Pages が自動デプロイ
+git push origin post/<slug>
+gh pr create --title "記事タイトル"
 ```
 
 ---
@@ -280,8 +280,8 @@ src/content/blog/2026/02/10/my-article/
 
 **Markdownでの参照:**
 ```markdown
-# 同じフォルダの画像を参照（ビルド後のパスを指定）
-![スクリーンショット](/images/blog/2026/02/10/my-article/screenshot.jpg)
+# 同じフォルダの画像は相対パスで参照
+![スクリーンショット](./screenshot.jpg)
 
 # アイキャッチ画像（frontmatterで指定）
 ---
@@ -452,7 +452,7 @@ npm run dev
 git add .
 git commit -m "Add new blog post: 記事タイトル
 
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 
 # 4. GitHubにプッシュ
 git push origin main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ node scripts/generate-ico.js
 
 # 4. ビルド＆デプロイ
 npm run build
-npx wrangler pages deploy dist --project-name=reiblast-portfolio --branch=main
+npx wrangler pages deploy dist --project-name=reiblast-f5-si --branch=main
 ```
 
 ### HTMLへの組み込み
@@ -228,6 +228,17 @@ draft: false
 | `#ff007d` (ピンク) | 強い主張 |
 | `#7cd300` (黄緑) | 背景ハイライト |
 
+## blog-editor（WYSIWYG エディタ）
+
+`tools/blog-editor/` に Flask + TipTap ベースのローカル WYSIWYG エディタがあります。
+
+- **アクセス**: http://localhost:5000（VS Code Remote SSH ポートフォワード）
+- **エディタ**: TipTap 2.11.5（esm.sh CDN）
+- **カード挿入**: ツールバーの 📝 ⚠ 💡 🚨 🔖 📂 ボタン（自動で `.mdx` に切り替わり import も追加）
+- **文字色・背景色**: カラーパレットをワンクリック
+- **保存**: 自動で `post/<slug>` ブランチを作成してコミット
+- **サービス管理**: `systemctl --user restart blog-editor`
+
 ## 今後の改善予定
 
 GitHubにIssueを作成済み：
@@ -240,9 +251,9 @@ GitHubにIssueを作成済み：
 - **#8**: カスタム404ページの作成 - Low
 - **#9**: プロジェクト詳細ページの追加 - Medium
 - **#10**: About / Contact セクションの追加 - Medium
-- **#53**: blog-editor からブランチ作成・PR作成・記事公開をできるようにする
+- **#53**: blog-editor からブランチ作成・PR作成・記事公開をできるようにする（ブランチ作成・コミットは実装済み）
 - **#54**: blog-editor を PWA 化する
 
 ---
 
-_Last updated: 2026-02-22_
+_Last updated: 2026-04-14_

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm run preview
 
 ```bash
 npm run build
-npx wrangler pages deploy dist --project-name=reiblast-portfolio
+npx wrangler pages deploy dist --project-name=reiblast-f5-si
 ```
 
 または

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,17 +2,27 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
+import react from '@astrojs/react';
+import keystatic from '@keystatic/astro';
+import cloudflare from '@astrojs/cloudflare';
 import { fileURLToPath } from 'url';
 import path from 'path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const isProd = process.env.NODE_ENV === 'production';
+
 // https://astro.build/config
 export default defineConfig({
-  output: 'static',
+  // 'server' is required so Keystatic's /api/keystatic/update POST endpoint
+  // is routed through the SSR pipeline. Static pages opt in via `prerender = true`.
+  output: 'server',
+  adapter: cloudflare(),
   site: 'https://reiblast1123.com',
-  trailingSlash: 'always',
-  integrations: [mdx(), sitemap()],
+  // Keystatic API breaks when Astro enforces trailing-slash redirects on POSTs.
+  // See https://github.com/Thinkmill/keystatic/issues/1042
+  trailingSlash: isProd ? 'always' : 'never',
+  integrations: [mdx(), sitemap(), react(), keystatic()],
   markdown: {
     shikiConfig: {
       theme: 'one-dark-pro',

--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -1,0 +1,39 @@
+import { config, collection, fields } from '@keystatic/core';
+
+export default config({
+  storage: {
+    kind: 'local',
+  },
+  collections: {
+    blog: collection({
+      label: 'Blog Posts',
+      // _path is the Keystatic-internal slug (derived from directory path, NOT written to frontmatter).
+      // Using a dedicated field avoids removing `title` or `slug` from the .md file.
+      slugField: '_path',
+      path: 'src/content/blog/**/',
+      format: { contentField: 'body' },
+      entryLayout: 'content',
+      schema: {
+        // _path: Keystatic slugField — value = YYYY/MM/DD/<slug>, set at creation time.
+        // This field is intentionally NOT in the Astro content schema (config.ts).
+        _path: fields.text({ label: '記事パス (YYYY/MM/DD/slug-name)', validation: { length: { min: 1 } } }),
+        title: fields.text({ label: 'タイトル', validation: { length: { min: 1 } } }),
+        description: fields.text({ label: '説明文', multiline: true }),
+        pubDate: fields.datetime({ label: '公開日時' }),
+        updatedDate: fields.datetime({ label: '更新日時', validation: { isRequired: false } }),
+        author: fields.text({ label: '著者', defaultValue: 'reiblast1123' }),
+        tags: fields.array(
+          fields.text({ label: 'タグ' }),
+          { label: 'タグ', itemLabel: (props) => props.value }
+        ),
+        image: fields.text({ label: 'ヒーロー画像パス', validation: { isRequired: false } }),
+        draft: fields.checkbox({ label: '下書き', defaultValue: false }),
+        slug: fields.text({ label: 'スラッグ (URLに使うID)', validation: { isRequired: false } }),
+        body: fields.markdoc({
+          label: '本文',
+          extension: 'md',
+        }),
+      },
+    }),
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,35 @@
       "dependencies": {
         "@astrojs/cloudflare": "^12.6.12",
         "@astrojs/mdx": "^4.3.13",
+        "@astrojs/react": "^5.0.3",
         "@astrojs/rss": "^4.0.15",
         "@astrojs/sitemap": "^3.7.0",
-        "astro": "^5.17.1"
+        "@keystatic/astro": "^5.0.6",
+        "@keystatic/core": "^0.5.50",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "astro": "^5.17.1",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5"
       },
       "devDependencies": {
         "@resvg/resvg-js": "^2.6.2",
         "glob": "^11.0.0",
         "to-ico": "^1.1.5"
+      }
+    },
+    "node_modules/@0no-co/graphql.web": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
+      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/@astrojs/cloudflare": {
@@ -117,6 +138,568 @@
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
+    "node_modules/@astrojs/react": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-5.0.3.tgz",
+      "integrity": "sha512-z6JXjgADH4/7e0hqcRj+dO9UQlrKmsm2ZJoVT1GzOTYY0ThQ3Znpfr8tY8XKlEHWSTUlT9LP5u4v6QpEJwLz5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.8.0",
+        "@vitejs/plugin-react": "^5.2.0",
+        "devalue": "^5.6.4",
+        "ultrahtml": "^1.6.0",
+        "vite": "^7.3.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+        "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@astrojs/internal-helpers": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.8.0.tgz",
+      "integrity": "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.3"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@astrojs/rss": {
       "version": "4.0.15",
       "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.15.tgz",
@@ -162,6 +745,182 @@
       "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
       "license": "MIT"
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -176,6 +935,28 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -195,6 +976,77 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
@@ -207,6 +1059,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
+      "license": "MIT"
     },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
@@ -354,6 +1212,127 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -769,6 +1748,119 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.8.tgz",
+      "integrity": "sha512-AuYeDoaR8jtUlUXtZ1IJ/6jtBkGnSpJXbGNzokBL87VDJ8opMq1Bgrc0szhK482ReQY6KZsMoZCVSb4xwalkBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.1",
+        "aria-hidden": "^1.2.3",
+        "tabbable": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@img/colour": {
@@ -1237,6 +2329,43 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
+      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/message": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
+      "integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
+      "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.7.tgz",
+      "integrity": "sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -1270,6 +2399,46 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1293,6 +2462,274 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@keystar/ui": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/@keystar/ui/-/ui-0.7.21.tgz",
+      "integrity": "sha512-DgAfdtcieYMMG5S0EaGf/F8T8e5nol9iLfZqIZOXHkjnc7UBHY3qHea2Zzd0hUrIoAcXiv4JyCtAND0vNKjJYA==",
+      "license": "MIT AND Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/react": "^0.24.0",
+        "@internationalized/date": "^3.8.0",
+        "@internationalized/string": "^3.2.6",
+        "@react-aria/actiongroup": "^3.7.15",
+        "@react-aria/breadcrumbs": "^3.5.23",
+        "@react-aria/button": "^3.13.0",
+        "@react-aria/calendar": "^3.8.0",
+        "@react-aria/checkbox": "^3.15.4",
+        "@react-aria/combobox": "^3.12.2",
+        "@react-aria/datepicker": "^3.14.2",
+        "@react-aria/dialog": "^3.5.24",
+        "@react-aria/dnd": "^3.9.2",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/gridlist": "^3.12.0",
+        "@react-aria/i18n": "^3.12.8",
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/label": "^3.7.17",
+        "@react-aria/link": "^3.8.0",
+        "@react-aria/listbox": "^3.14.3",
+        "@react-aria/live-announcer": "^3.4.2",
+        "@react-aria/menu": "^3.18.2",
+        "@react-aria/meter": "^3.4.22",
+        "@react-aria/numberfield": "^3.11.13",
+        "@react-aria/overlays": "^3.27.0",
+        "@react-aria/progress": "^3.4.22",
+        "@react-aria/radio": "^3.11.2",
+        "@react-aria/searchfield": "^3.8.3",
+        "@react-aria/select": "^3.15.4",
+        "@react-aria/selection": "^3.24.0",
+        "@react-aria/separator": "^3.4.8",
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/switch": "^3.7.2",
+        "@react-aria/table": "^3.17.2",
+        "@react-aria/tabs": "^3.10.2",
+        "@react-aria/tag": "^3.5.2",
+        "@react-aria/textfield": "^3.17.2",
+        "@react-aria/toast": "3.0.2",
+        "@react-aria/tooltip": "^3.8.2",
+        "@react-aria/utils": "^3.28.2",
+        "@react-aria/virtualizer": "^4.1.4",
+        "@react-aria/visually-hidden": "^3.8.22",
+        "@react-stately/calendar": "^3.8.0",
+        "@react-stately/checkbox": "^3.6.13",
+        "@react-stately/collections": "^3.12.3",
+        "@react-stately/combobox": "^3.10.4",
+        "@react-stately/data": "^3.12.3",
+        "@react-stately/datepicker": "^3.14.0",
+        "@react-stately/dnd": "^3.5.3",
+        "@react-stately/form": "^3.1.3",
+        "@react-stately/layout": "^4.2.2",
+        "@react-stately/list": "^3.12.1",
+        "@react-stately/menu": "^3.9.3",
+        "@react-stately/numberfield": "^3.9.11",
+        "@react-stately/overlays": "^3.6.15",
+        "@react-stately/radio": "^3.10.12",
+        "@react-stately/searchfield": "^3.5.11",
+        "@react-stately/select": "^3.6.12",
+        "@react-stately/selection": "^3.20.1",
+        "@react-stately/table": "^3.14.1",
+        "@react-stately/tabs": "^3.8.1",
+        "@react-stately/toast": "3.1.0",
+        "@react-stately/toggle": "^3.8.3",
+        "@react-stately/tooltip": "^3.5.3",
+        "@react-stately/tree": "^3.8.9",
+        "@react-stately/utils": "^3.10.6",
+        "@react-stately/virtualizer": "^4.3.2",
+        "@react-types/actionbar": "^3.1.14",
+        "@react-types/actiongroup": "^3.4.16",
+        "@react-types/breadcrumbs": "^3.7.12",
+        "@react-types/button": "^3.12.0",
+        "@react-types/calendar": "^3.7.0",
+        "@react-types/combobox": "^3.13.4",
+        "@react-types/datepicker": "^3.12.0",
+        "@react-types/grid": "^3.3.1",
+        "@react-types/menu": "^3.10.0",
+        "@react-types/numberfield": "^3.8.10",
+        "@react-types/overlays": "^3.8.14",
+        "@react-types/radio": "^3.8.8",
+        "@react-types/select": "^3.9.11",
+        "@react-types/shared": "^3.29.0",
+        "@react-types/switch": "^3.5.10",
+        "@react-types/table": "^3.12.0",
+        "@react-types/tabs": "^3.3.14",
+        "@types/react": "^19.0.8",
+        "emery": "^1.4.1",
+        "facepaint": "^1.2.1"
+      },
+      "peerDependencies": {
+        "next": ">=14",
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@keystatic/astro": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@keystatic/astro/-/astro-5.0.6.tgz",
+      "integrity": "sha512-kUBXkXpE9/JH2fFx0in+tym6YVIDoHgxW9J9WHOJ+uwbpJJcUH6IRqVyutgZr8DO/UDaAhoZc41zcIUyWz0Trw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@types/react": "^19.0.8",
+        "set-cookie-parser": "^2.5.1"
+      },
+      "peerDependencies": {
+        "@keystatic/core": "*",
+        "astro": "2 || 3 || 4 || 5",
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@keystatic/core": {
+      "version": "0.5.50",
+      "resolved": "https://registry.npmjs.org/@keystatic/core/-/core-0.5.50.tgz",
+      "integrity": "sha512-ilgG9hw1iWZsT8iCV+1WFX1VNo6eK+iHIs61x4vRtce6SstKad6ib7BLhXEP41Q8ja6JIKWXvv6qBPVumyy88Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@braintree/sanitize-url": "^6.0.2",
+        "@emotion/weak-memoize": "^0.3.0",
+        "@floating-ui/react": "^0.24.0",
+        "@internationalized/string": "^3.2.6",
+        "@keystar/ui": "^0.7.21",
+        "@markdoc/markdoc": "^0.4.0",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/i18n": "^3.12.8",
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/label": "^3.7.17",
+        "@react-aria/overlays": "^3.27.0",
+        "@react-aria/selection": "^3.24.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-aria/visually-hidden": "^3.8.22",
+        "@react-stately/collections": "^3.12.3",
+        "@react-stately/list": "^3.12.1",
+        "@react-stately/overlays": "^3.6.15",
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/shared": "^3.29.0",
+        "@sindresorhus/slugify": "^1.1.2",
+        "@toeverything/y-indexeddb": "^0.10.0-canary.9",
+        "@ts-gql/tag": "^0.7.3",
+        "@types/react": "^19.0.8",
+        "@urql/core": "^5.0.4",
+        "@urql/exchange-auth": "^2.2.0",
+        "@urql/exchange-graphcache": "^7.1.2",
+        "@urql/exchange-persisted": "^4.3.0",
+        "cookie": "^1.0.0",
+        "emery": "^1.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "graphql": "^16.6.0",
+        "idb-keyval": "^6.2.1",
+        "ignore": "^5.2.4",
+        "is-hotkey": "^0.2.0",
+        "js-yaml": "^4.1.0",
+        "lib0": "^0.2.88",
+        "lru-cache": "^10.2.0",
+        "match-sorter": "^6.3.1",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-mdx": "^3.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-mdxjs": "^3.0.0",
+        "minimatch": "^9.0.3",
+        "partysocket": "^0.0.22",
+        "prosemirror-commands": "^1.5.1",
+        "prosemirror-history": "^1.3.0",
+        "prosemirror-keymap": "^1.2.1",
+        "prosemirror-model": "^1.19.0",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-tables": "^1.3.4",
+        "prosemirror-transform": "^1.7.1",
+        "prosemirror-view": "^1.30.2",
+        "scroll-into-view-if-needed": "^3.0.3",
+        "slate": "^0.91.4",
+        "slate-history": "^0.86.0",
+        "slate-react": "^0.91.9",
+        "superstruct": "^1.0.4",
+        "unist-util-visit": "^5.0.0",
+        "urql": "^4.1.0",
+        "y-prosemirror": "^1.2.2",
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.11"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@keystatic/core/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@keystatic/core/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@keystatic/core/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@markdoc/markdoc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.4.0.tgz",
+      "integrity": "sha512-fSh4P3Y4E7oaKYc2oNzSIJVPDto7SMzAuQN1Iyx53UxzleA6QzRdNWRxmiPqtVDaDi5dELd2yICoG91csrGrAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.7.0"
+      },
+      "optionalDependencies": {
+        "@types/markdown-it": "12.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mdx-js/mdx": {
@@ -1372,6 +2809,1609 @@
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "license": "MIT"
+    },
+    "node_modules/@react-aria/actiongroup": {
+      "version": "3.7.24",
+      "resolved": "https://registry.npmjs.org/@react-aria/actiongroup/-/actiongroup-3.7.24.tgz",
+      "integrity": "sha512-OyoNHZTxAcdKAoolWT3anEPCXilsWw65YiyCnV+8Vr9JjP2ON1w1cyVv7pnfRots4E1luydsWbRS/CMER4Za7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/list": "^3.13.4",
+        "@react-types/actiongroup": "^3.4.23",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/breadcrumbs": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.32.tgz",
+      "integrity": "sha512-S61vh5DJ2PXiXUwD7gk+pvS/b4VPrc3ZJOUZ0yVRLHkVESr5LhIZH+SAVgZkm1lzKyMRG+BH+fiRH/DZRSs7SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/link": "^3.8.9",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/breadcrumbs": "^3.7.19",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/button": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.14.5.tgz",
+      "integrity": "sha512-ZuLx+wQj9VQhH9BYe7t0JowmKnns2XrFHFNvIVBb5RwxL+CIycIOL7brhWKg2rGdxvlOom7jhVbcjSmtAaSyaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/toolbar": "3.0.0-beta.24",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/calendar": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.9.5.tgz",
+      "integrity": "sha512-k0kvceYdZZu+DoeqephtlmIvh1CxqdFyoN52iqVzTz9O0pe5Xfhq7zxPGbeCp4pC61xzp8Lu/6uFA/YNfQQNag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/calendar": "^3.9.3",
+        "@react-types/button": "^3.15.1",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/checkbox": {
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.16.5.tgz",
+      "integrity": "sha512-ZhUT7ELuD52hb+Zpzw0ElLQiVOd5sKYahrh+PK3vq13Wk5TedBscALpjuXetI4pwFfdmAM1Lhgcsrd8+6AmyvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/toggle": "^3.12.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/checkbox": "^3.7.5",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/combobox": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.15.0.tgz",
+      "integrity": "sha512-qSjQTFwKl3x1jCP2NRSJ6doZqAp6c2GTfoiFwWjaWg1IewwLsglaW6NnzqRDFiqFbDGgXPn4MqtC1VYEJ3NEjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/listbox": "^3.15.3",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/menu": "^3.21.0",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/combobox": "^3.13.0",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/combobox": "^3.14.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/datepicker": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.16.1.tgz",
+      "integrity": "sha512-6BltCVWt09yefTkGjb2gViGCwoddx9HKJiZbY9u6Es/Q+VhwNJQRtczbnZ3K32p262hIknukNf/5nZaCOI1AKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/spinbutton": "^3.7.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/datepicker": "^3.16.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/datepicker": "^3.13.5",
+        "@react-types/dialog": "^3.5.24",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dialog": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.34.tgz",
+      "integrity": "sha512-/x53Q5ynpW5Kv9637WYu7SrDfj3woSp6jJRj8l6teGnWW/iNZWYJETgzHfbxx+HPKYATCZesRoIeO2LnYIXyEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/dialog": "^3.5.24",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dnd": {
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/dnd/-/dnd-3.11.6.tgz",
+      "integrity": "sha512-4YLHUeYJleF+moAYaYt8UZqujudPvpoaHR+QMkWIFzhfridVUhCr6ZjGWrzpSZY3r68k46TG7YCsi4IEiNnysw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/dnd": "^3.7.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.5.tgz",
+      "integrity": "sha512-V18fwCyf8zqgJdpLQeDU5ZRNd9TeOfBbhLgmX77Zr5ae9XwaoJ1R3SFJG1wCJX60t34AW+aLZSEEK+saQElf3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/form": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.1.5.tgz",
+      "integrity": "sha512-BWlONgHn8hmaMkcS6AgMSLQeNqVBwqPNLhdqjDO/PCfzvV7O8NZw/dFeIzJwfG4aBfSpbHHRdXGdfrk3d8dylQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid": {
+      "version": "3.14.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.14.8.tgz",
+      "integrity": "sha512-X6rRFKDu/Kh6Sv8FBap3vjcb+z4jXkSOwkYnexIJp5kMTo5/Dqo55cCBio5B70Tanfv32Ev/6SpzYG7ryxnM9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/grid": "^3.11.9",
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/gridlist": {
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/gridlist/-/gridlist-3.14.4.tgz",
+      "integrity": "sha512-C/SbwC0qagZatoBrCjx8iZUex9apaJ8o8iRJ9eVHz0cpj7mXg6HuuotYGmDy9q67A2hve4I693RM1Cuwqwm+PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/grid": "^3.14.8",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/list": "^3.13.4",
+        "@react-stately/tree": "^3.9.6",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/i18n": {
+      "version": "3.12.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.16.tgz",
+      "integrity": "sha512-Km2CAz6MFQOUEaattaW+2jBdWOHUF8WX7VQoNbjlqElCP58nSaqi9yxTWUDRhAcn8/xFUnkFh4MFweNgtrHuEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/message": "^3.1.8",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.27.1.tgz",
+      "integrity": "sha512-M3wLpTTmDflI0QGNK0PJNUaBXXfeBXue8ZxLMngfc1piHNiH4G5lUvWd9W14XVbqrSCVY8i8DfGrNYpyyZu0tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/label": {
+      "version": "3.7.25",
+      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.25.tgz",
+      "integrity": "sha512-oNK3Pqj4LDPwEbQaoM/uCip4QvQmmwGOh08VeW+vzSi6TAwf+KoWTyH/tiAeB0CHWNDK0k3e1iTygTAt4wzBmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/landmark": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/landmark/-/landmark-3.0.10.tgz",
+      "integrity": "sha512-GpNjJaI8/a6WxYDZgzTCLYSzPM6xp2pxCIQ4udiGbTCtxx13Trmm0cPABvPtzELidgolCf05em9Phr+3G0eE8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/link": {
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.8.9.tgz",
+      "integrity": "sha512-UaAFBfs84/Qq6TxlMWkREqqNY6SFLukot+z2Aa1kC+VyStv1kWG6sE5QLjm4SBn1Q3CGRsefhB/5+taaIbB4Pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/link": "^3.6.7",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/listbox": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.15.3.tgz",
+      "integrity": "sha512-C6YgiyrHS5sbS5UBdxGMhEs+EKJYotJgGVtl9l0ySXpBUXERiHJWLOyV7a8PwkUOmepbB4FaLD7Y9EUzGkrGlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/list": "^3.13.4",
+        "@react-types/listbox": "^3.7.6",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/live-announcer": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.4.tgz",
+      "integrity": "sha512-PTTBIjNRnrdJOIRTDGNifY2d//kA7GUAwRFJNOEwSNG4FW+Bq9awqLiflw0JkpyB0VNIwou6lqKPHZVLsGWOXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-aria/menu": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.21.0.tgz",
+      "integrity": "sha512-CKTVZ4izSE1eKIti6TbTtzJAUo+WT8O4JC0XZCYDBpa0f++lD19Kz9aY+iY1buv5xGI20gAfpO474E9oEd4aQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/menu": "^3.9.11",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/tree": "^3.9.6",
+        "@react-types/button": "^3.15.1",
+        "@react-types/menu": "^3.10.7",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/meter": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.4.30.tgz",
+      "integrity": "sha512-ZmANKW7s/Z4QGylHi46nhwtQ47T1bfMsU9MysBu7ViXXNJ03F4b6JXCJlKL5o2goQ3NbfZ68GeWamIT0BWSgtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/progress": "^3.4.30",
+        "@react-types/meter": "^3.4.15",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/numberfield": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.12.5.tgz",
+      "integrity": "sha512-Fi41IUWXEHLFIeJ/LHuZ9Azs8J/P563fZi37GSBkIq5P1pNt1rPgJJng5CNn4KsHxwqadTRUlbbZwbZraWDtRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/spinbutton": "^3.7.2",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/numberfield": "^3.11.0",
+        "@react-types/button": "^3.15.1",
+        "@react-types/numberfield": "^3.8.18",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/overlays": {
+      "version": "3.31.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.31.2.tgz",
+      "integrity": "sha512-78HYI08r6LvcfD34gyv19ArRIjy1qxOKuXl/jYnjLDyQzD4pVb634IQWcm0zt10RdKgyuH6HTqvuDOgZTLet7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/button": "^3.15.1",
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/progress": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.30.tgz",
+      "integrity": "sha512-S6OWVGgluSWYSd/A6O8CVjz83eeMUfkuWSra0ewAV9bmxZ7TP9pUmD3bGdqHZEl97nt5vHGjZ3eq/x8eCmzKhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/progress": "^3.5.18",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/radio": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.12.5.tgz",
+      "integrity": "sha512-8CCJKJzfozEiWBPO9QAATG1rBGJEJ+xoqvHf9LKU2sPFGsA2/SRnLs6LB9fCG5R3spvaK1xz0any1fjWPl7x8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/radio": "^3.11.5",
+        "@react-types/radio": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/searchfield": {
+      "version": "3.8.12",
+      "resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.8.12.tgz",
+      "integrity": "sha512-kYlUHD/+mWzNroHoR8ojUxYBoMviRZn134WaKPFjfNUGZDOEuh4XzOoj+cjdJfe6N3mwTaYu6rJQtunSHIAfhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/searchfield": "^3.5.19",
+        "@react-types/button": "^3.15.1",
+        "@react-types/searchfield": "^3.6.8",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/select": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.17.3.tgz",
+      "integrity": "sha512-u0UFWw0S7q9oiSbjetDpRoLLIcC+L89uYlm+YfCrdT8ntbQgABNiJRxdVvxnhR0fR6MC9ASTTvuQnNHNn52+1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/listbox": "^3.15.3",
+        "@react-aria/menu": "^3.21.0",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/select": "^3.9.2",
+        "@react-types/button": "^3.15.1",
+        "@react-types/select": "^3.12.2",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/selection": {
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.27.2.tgz",
+      "integrity": "sha512-GbUSSLX/ciXix95KW1g+SLM9np7iXpIZrFDSXkC6oNx1uhy18eAcuTkeZE25+SY5USVUmEzjI3m/3JoSUcebbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/separator": {
+      "version": "3.4.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.4.16.tgz",
+      "integrity": "sha512-RCUtQhDGnPxKzyG8KM79yOB0fSiEf8r/rxShidOVnGLiBW2KFmBa22/Gfc4jnqg/keN3dxvkSGoqmeXgctyp6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.7.2.tgz",
+      "integrity": "sha512-adjE1wNCWlugvAtVXlXWPtIG9JWurEgYVn1Eeyh19x038+oXGvOsOAoKCXM+SnGleTWQ9J7pEZITFoEI3cVfAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/switch": {
+      "version": "3.7.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.7.11.tgz",
+      "integrity": "sha512-dYVX71HiepBsKyeMaQgHbhqI+MQ3MVoTd5EnTbUjefIBnmQZavYj1/e4NUiUI4Ix+/C0HxL8ibDAv4NlSW3eLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/toggle": "^3.12.5",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/switch": "^3.5.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/table": {
+      "version": "3.17.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.17.11.tgz",
+      "integrity": "sha512-GkYmWPiW3OM+FUZxdS33teHXHXde7TjHuYgDDaG9phvg6cQTQjGilJozrzA3OfftTOq5VB8XcKTIQW3c0tpYsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/grid": "^3.14.8",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/table": "^3.15.4",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tabs": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.11.1.tgz",
+      "integrity": "sha512-3Ppz7yaEDW9L7p9PE9yNOl5caLwNnnLQqI+MX/dwbWlw9HluHS7uIjb21oswNl6UbSxAWyENOka45+KN4Fkh7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/tabs": "^3.8.9",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tabs": "^3.3.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tag": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.8.1.tgz",
+      "integrity": "sha512-VonpO++F8afXGDWc9VUxAc2wefyJpp1n9OGpbnB7zmqWiuPwO/RixjUdcH7iJkiC4vADwx9uLnhyD6kcwGV2ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.14.4",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/list": "^3.13.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/textfield": {
+      "version": "3.18.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.18.5.tgz",
+      "integrity": "sha512-ttwVSuwoV3RPaG2k2QzEXKeQNQ3mbdl/2yy6I4Tjrn1ZNkYHfVyJJ26AjenfSmj1kkTQoSAfZ8p+7rZp4n0xoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/textfield": "^3.12.8",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toast": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/toast/-/toast-3.0.2.tgz",
+      "integrity": "sha512-iaiHDE1CKYM3BbNEp3A2Ed8YAlpXUGyY6vesKISdHEZ2lJ7r+1hbcFoTNdG8HfbB8Lz5vw8Wd2o+ZmQ2tnDY9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.8",
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/landmark": "^3.0.2",
+        "@react-aria/utils": "^3.28.2",
+        "@react-stately/toast": "^3.1.0",
+        "@react-types/button": "^3.12.0",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.12.5.tgz",
+      "integrity": "sha512-XXVFLzcV8fr9mz7y/wfxEAhWvaBZ9jSfhCMuxH2bsivO7nTcMJ1jb4g2xJNwZgne17bMWNc7mKvW5dbsdlI6BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toolbar": {
+      "version": "3.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.24.tgz",
+      "integrity": "sha512-B2Rmpko7Ghi2RbNfsGdbR7I+RQBDhPGVE4bU3/EwHz+P/vNe5LyGPTeSwqaOMsQTF9lKNCkY8424dVTCr6RUMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tooltip": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.9.2.tgz",
+      "integrity": "sha512-VrgkPwHiEnAnBhoQ4W7kfry/RfVuRWrUPaJSp0+wKM6u0gg2tmn7OFRDXTxBAm/omQUguIdIjRWg7sf3zHH82A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/tooltip": "^3.5.11",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tooltip": "^3.5.2",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.33.1.tgz",
+      "integrity": "sha512-kIx1Sj6bbAT0pdqCegHuPanR9zrLn5zMRiM7LN12rgRf55S19ptd9g3ncahArifYTRkfEU9VIn+q0HjfMqS9/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/virtualizer": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@react-aria/virtualizer/-/virtualizer-4.1.13.tgz",
+      "integrity": "sha512-d5KS+p8GXGNRbGPRE/N6jtth3et3KssQIz52h2+CAoAh7C3vvR64kkTaGdeywClvM+fSo8FxJuBrdfQvqC2ktQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/virtualizer": "^4.4.6",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.31",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.31.tgz",
+      "integrity": "sha512-RTOHHa4n56a9A3criThqFHBifvZoV71+MCkSuNP2cKO662SUWjqKkd0tJt/mBRMEJPkys8K7Eirp6T8Wt5FFRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/calendar": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.9.3.tgz",
+      "integrity": "sha512-uw7fCZXoypSBBUsVkbNvJMQWTihZReRbyLIGG3o/ZM630N3OCZhb/h4Uxke4pNu7n527H0V1bAnZgAldIzOYqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/checkbox": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.7.5.tgz",
+      "integrity": "sha512-K5R5ted7AxLB3sDkuVAazUdyRMraFT1imVqij2GuAiOUFvsZvbuocnDuFkBVKojyV3GpqLBvViV8IaCMc4hNIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/collections": {
+      "version": "3.12.10",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.10.tgz",
+      "integrity": "sha512-wmF9VxJDyBujBuQ76vXj2g/+bnnj8fx5DdXgRmyfkkYhPB46+g2qnjbVGEvipo7bJuGxDftCUC4SN7l7xqUWfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/combobox": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.13.0.tgz",
+      "integrity": "sha512-dX9g/cK1hjLRjcbWVF6keHxTQDGhKGB2QAgPhWcBmOK3qJv+2dQqsJ6YCGWn/Y2N2acoEseLrAA7+Qe4HWV9cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/list": "^3.13.4",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/combobox": "^3.14.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/data": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.15.2.tgz",
+      "integrity": "sha512-BsmeeGgFwOGwo0g9Waprdyt+846n3KhKggZfpEnp5+sC4dE4uW1VIYpdyupMfr3bQcmX123q6TegfNP3eszrUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/datepicker": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.16.1.tgz",
+      "integrity": "sha512-BtAMDvxd1OZxkxjqq5tN5TYmp6Hm8+o3+IDA4qmem2/pfQfVbOZeWS2WitcPBImj4n4T+W1A5+PI7mT/6DUBVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/datepicker": "^3.13.5",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/dnd": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.7.4.tgz",
+      "integrity": "sha512-YD0TVR5JkvTqskc1ouBpVKs6t/QS4RYCIyu8Ug8RgO122iIizuf2pfKnRLjYMdu5lXzBXGaIgd49dvnLzEXHIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/form": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.2.4.tgz",
+      "integrity": "sha512-qNBzun8SbLdgahryhKLqL1eqP+MXY6as82sVXYOOvUYLzgU5uuN8mObxYlxJgMI5akSdQJQV3RzyfVobPRE7Kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/grid": {
+      "version": "3.11.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.11.9.tgz",
+      "integrity": "sha512-qQY6F+27iZRn30dt0ZOrSetUmbmNJ0pLe9Weuqw3+XDVSuWT+2O/rO1UUYeK+mO0Acjzdv+IWiYbu9RKf2wS9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/layout": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-4.6.0.tgz",
+      "integrity": "sha512-kBenEsP03nh5rKgfqlVMPcoKTJv0v92CTvrAb5gYY8t9g8LOwzdL89Yannq7f5xv8LFck/MmRQlotpMt2InETg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/table": "^3.15.4",
+        "@react-stately/virtualizer": "^4.4.6",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/list": {
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.13.4.tgz",
+      "integrity": "sha512-HHYSjA9VG7FPSAtpXAjQyM/V7qFHWGg88WmMrDt5QDlTBexwPuH0oFLnW0qaVZpAIxuWIsutZfxRAnme/NhhAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/menu": {
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.11.tgz",
+      "integrity": "sha512-vYkpO9uV2OUecsIkrOc+Urdl/s1xw/ibNH/UXsp4PtjMnS6mK9q2kXZTM3WvMAKoh12iveUO+YkYCZQshmFLHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/menu": "^3.10.7",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/numberfield": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.11.0.tgz",
+      "integrity": "sha512-rxfC047vL0LP4tanjinfjKAriAvdVL57Um5RUL5nHML8IOWCB3TBxegQkJ6to6goScC/oZhd0/Y2LSaiRuKbNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.5",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/numberfield": "^3.8.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/overlays": {
+      "version": "3.6.23",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.23.tgz",
+      "integrity": "sha512-RzWxots9A6gAzQMP4s8hOAHV7SbJRTFSlQbb6ly1nkWQXacOSZSFNGsKOaS0eIatfNPlNnW4NIkgtGws5UYzfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/overlays": "^3.9.4",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/radio": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.11.5.tgz",
+      "integrity": "sha512-QxA779S4ea5icQ0ja7CeiNzY1cj7c9G9TN0m7maAIGiTSinZl2Ia8naZJ0XcbRRp+LBll7RFEdekne15TjvS/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/radio": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/searchfield": {
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.5.19.tgz",
+      "integrity": "sha512-URllgjbtTQEaOCfddbHpJSPKOzG3pE3ajQHJ7Df8qCoHTjKfL6hnm/vp7X5sxPaZaN7VLZ5kAQxTE8hpo6s0+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/searchfield": "^3.6.8",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.9.2.tgz",
+      "integrity": "sha512-oWn0bijuusp8YI7FRM/wgtPVqiIrgU/ZUfLKe/qJUmT8D+JFaMAJnyrAzKpx98TrgamgtXynF78ccpopPhgrKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/list": "^3.13.4",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/select": "^3.12.2",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection": {
+      "version": "3.20.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.20.9.tgz",
+      "integrity": "sha512-RhxRR5Wovg9EVi3pq7gBPK2BoKmP59tOXDMh2r1PbnGevg/7TNdR67DCEblcmXwHuBNS46ELfKdd0XGHqmS8nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/table": {
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.15.4.tgz",
+      "integrity": "sha512-fGaNyw3wv7JgRCNzgyDzpaaTFuSy5f4Qekch4UheMXDJX7dOeaMhUXeOfvnXCVg+BGM4ey/D82RvDOGvPy1Nww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/grid": "^3.11.9",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tabs": {
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.8.9.tgz",
+      "integrity": "sha512-AQ4Xrn6YzIolaVShCV9cnwOjBKPAOGP/PTp7wpSEtQbQ0HZzUDG2RG/M4baMeUB2jZ33b7ifXyPcK78o0uOftg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/list": "^3.13.4",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tabs": "^3.3.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toast": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/toast/-/toast-3.1.0.tgz",
+      "integrity": "sha512-9W2+evz+EARrjkR1QPLlOL5lcNpVo6PjMAIygRSaCPJ6ftQAZ6B+7xTFGPFabWh83gwXQDUgoSwC3/vosvxZaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toggle": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.9.5.tgz",
+      "integrity": "sha512-PVzXc788q3jH98Kvw1LYDL+wpVC14dCEKjOku8cSaqhEof6AJGaLR9yq+EF1yYSL2dxI6z8ghc0OozY8WrcFcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tooltip": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.11.tgz",
+      "integrity": "sha512-o8PnFXbvDCuVZ4Ht9ahfS6KHwIZjXopvoQ2vUPxv920irdgWEeC+4omgDOnJ/xFvcpmmJAmSsrQsTQrTguDUQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/tooltip": "^3.5.2",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tree": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.9.6.tgz",
+      "integrity": "sha512-JCuhGyX2A+PAMsx2pRSwArfqNFZJ9JSPkDaOQJS8MFPAsBe5HemvXsdmv9aBIMzlbCYcVq6EsrFnzbVVTBt/6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
+      "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/virtualizer": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.4.6.tgz",
+      "integrity": "sha512-9SfXgLFB61/8SXNLfg5ARx9jAK4m03Aw6/Cg8mdZN24SYarL4TKNRpfw8K/HHVU/bi6WHSJypk6Z/z19o/ztrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/actionbar": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@react-types/actionbar/-/actionbar-3.1.21.tgz",
+      "integrity": "sha512-X2PZrYxkFow4M0nnAG16aDoErMFoI+qHGB5n4ytLdPF3+ea4PsxvL1Z9KrpiB2ELuOCx77RaGnuXcfyXK/HaKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/actiongroup": {
+      "version": "3.4.23",
+      "resolved": "https://registry.npmjs.org/@react-types/actiongroup/-/actiongroup-3.4.23.tgz",
+      "integrity": "sha512-FPd/2N3nfxVVP535JnMBu5jw40UrTAaQKLF+1dD+KQ3eHs2mNLfnPvJcY1HLj0mD/FhEFSbY8rJEDbcKCnBuhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/breadcrumbs": {
+      "version": "3.7.19",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.19.tgz",
+      "integrity": "sha512-AnkyYYmzaM2QFi/N0P/kQLM8tHOyFi7p397B/jEMucXDfwMw5Ny1ObCXeIEqbh8KrIa2Xp8SxmQlCV+8FPs4LA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/link": "^3.6.7",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/button": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.15.1.tgz",
+      "integrity": "sha512-M1HtsKreJkigCnqceuIT22hDJBSStbPimnpmQmsl7SNyqCFY3+DHS7y/Sl3GvqCkzxF7j9UTL0dG38lGQ3K4xQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/calendar": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.8.3.tgz",
+      "integrity": "sha512-fpH6WNXotzH0TlKHXXxtjeLZ7ko0sbyHmwDAwmDFyP7T0Iwn1YQZ+lhceLifvynlxuOgX6oBItyUKmkHQ0FouQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/checkbox": {
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.10.4.tgz",
+      "integrity": "sha512-tYCG0Pd1usEz5hjvBEYcqcA0youx930Rss1QBIse9TgMekA1c2WmPDNupYV8phpO8Zuej3DL1WfBeXcgavK8aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/combobox": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.14.0.tgz",
+      "integrity": "sha512-zmSSS7BcCOD8rGT8eGbVy7UlL5qq1vm88fFn4WgFe+lfK33ne+E7yTzTxcPY2TCGSo5fY6xMj3OG79FfVNGbSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/datepicker": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.13.5.tgz",
+      "integrity": "sha512-j28Vz+xvbb4bj7+9Xbpc4WTvSitlBvt7YEaEGM/8ZQ5g4Jr85H2KwkmDwjzmMN2r6VMQMMYq9JEcemq5wWpfUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/dialog": {
+      "version": "3.5.24",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.24.tgz",
+      "integrity": "sha512-NFurEP/zV0dA/41422lV1t+0oh6f/13n+VmLHZG8R13m1J3ql/kAXZ49zBSqkqANBO1ojyugWebk99IiR4pYOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/grid": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.8.tgz",
+      "integrity": "sha512-zJvXH8gc1e1VH2H3LRnHH/W2HIkLkZMH3Cu5pLcj0vDuLBSWpcr3Ikh3jZ+VUOZF0G1Jt1lO8pKIaqFzDLNmLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/link": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.6.7.tgz",
+      "integrity": "sha512-1apXCFJgMC1uydc2KNENrps1qR642FqDpwlNWe254UTpRZn/hEZhA6ImVr8WhomfLJu672WyWA0rUOv4HT+/pQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/listbox": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.7.6.tgz",
+      "integrity": "sha512-335NYElKEByXMalAmeRPyulKIDd2cjOCQhLwvv2BtxO5zaJfZnBbhZs+XPd9zwU6YomyOxODKSHrwbNDx+Jf3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/menu": {
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.10.7.tgz",
+      "integrity": "sha512-+p7ixZdvPDJZhisqdtWiiuJ9pteNfK5i19NB6wzAw5XkljbEzodNhwLv6rI96DY5XpbFso2kcjw7IWi+rAAGGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/meter": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.4.15.tgz",
+      "integrity": "sha512-9WjNphhLLM+TA4Ev1y2MkpugJ5JjTXseHh7ZWWx2veq5DrXMZYclkRpfUrUdLVKvaBIPQCgpQIj0TcQi+quR9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/progress": "^3.5.18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/numberfield": {
+      "version": "3.8.18",
+      "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.18.tgz",
+      "integrity": "sha512-nLzk7YAG9yAUtSv+9R8LgCHsu8hJq8/A+m1KsKxvc8WmNJjIujSFgWvT21MWBiUgPBzJKGzAqpMDDa087mltJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/overlays": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.9.4.tgz",
+      "integrity": "sha512-7Z9HaebMFyYBqtv3XVNHEmVkm7AiYviV7gv0c98elEN2Co+eQcKFGvwBM9Gy/lV57zlTqFX1EX/SAqkMEbCLOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/progress": {
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.18.tgz",
+      "integrity": "sha512-mKeQn+KrHr1y0/k7KtrbeDGDaERH6i4f6yBwj/ZtYDCTNKMO3tPHJY6nzF0w/KKZLplIO+BjUbHXc2RVm8ovwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/radio": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.9.4.tgz",
+      "integrity": "sha512-TkMRY3sA1PcFZhhclu4IUzUTIir6MzNJj8h6WT8vO6Nug2kXJ72qigugVFBWJSE472mltduOErEAo0rtAYWbQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/searchfield": {
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.6.8.tgz",
+      "integrity": "sha512-M2p7OVdMTMDmlBcHd4N2uCBwg3uJSNM4lmEyf09YD44N5wDAI0yogk52QBwsnhpe+i2s65UwCYgunB+QltRX8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@react-types/textfield": "^3.12.8"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/select": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.12.2.tgz",
+      "integrity": "sha512-AseOjfr3qM1W1qIWcbAe6NFpwZluVeQX/dmu9BYxjcnVvtoBLPMbE5zX/BPbv+N5eFYjoMyj7Ug9dqnI+LrlGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.33.1.tgz",
+      "integrity": "sha512-oJHtjvLG43VjwemQDadlR5g/8VepK56B/xKO2XORPHt9zlW6IZs3tZrYlvH29BMvoqC7RtE7E5UjgbnbFtDGag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/switch": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.17.tgz",
+      "integrity": "sha512-2GTPJvBCYI8YZ3oerHtXg+qikabIXCMJ6C2wcIJ5Xn0k9XOovowghfJi10OPB2GGyOiLBU74CczP5nx8adG90Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/table": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.13.6.tgz",
+      "integrity": "sha512-eluL+iFfnVmFm7OSZrrFG9AUjw+tcv898zbv+NsZACa8oXG1v9AimhZfd+Mo8q/5+sX/9hguWNXFkSvmTjuVPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs": {
+      "version": "3.3.22",
+      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.22.tgz",
+      "integrity": "sha512-HGwLD9dA3k3AGfRKGFBhNgxU9/LyRmxN0kxVj1ghA4L9S/qTOzS6GhrGNkGzsGxyVLV4JN8MLxjWN2o9QHnLEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/textfield": {
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.12.8.tgz",
+      "integrity": "sha512-wt6FcuE5AyntxsnPika/h3nf/DPmeAVbI018L9o6h+B/IL4sMWWdx663wx2KOOeHH8ejKGZQNPLhUKs4s1mVQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tooltip": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.5.2.tgz",
+      "integrity": "sha512-FvSuZ2WP08NEWefrpCdBYpEEZh/5TvqvGjq0wqGzWg2OPwpc14HjD8aE7I3MOuylXkD4MSlMjl7J4DlvlcCs3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/@resvg/resvg-js": {
       "version": "2.6.2",
@@ -1600,6 +4640,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -2033,11 +5079,159 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@sindresorhus/slugify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
+      "integrity": "sha512-V9nR/W0Xd9TSGXpZ4iFUcFGhuOJtZX82Fzxj1YISlbSgKvIiNa7eLEZrT0vAraPOt++KHauIVNYgGRgjc13dXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/transliterate": "^0.1.1",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/slugify/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/transliterate": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-0.1.2.tgz",
+      "integrity": "sha512-5/kmIOY9FF32nicXH+5yLNTX4NJ4atl7jRgqAJuIn/iyDFXBktOKDxCvyGE/EzmF4ngSUvjXxQUQlQiZ5lfw+w==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0",
+        "lodash.deburr": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/transliterate/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@speed-highlight/core": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
       "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
       "license": "CC0-1.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@toeverything/y-indexeddb": {
+      "version": "0.10.0-canary.9",
+      "resolved": "https://registry.npmjs.org/@toeverything/y-indexeddb/-/y-indexeddb-0.10.0-canary.9.tgz",
+      "integrity": "sha512-3hzktNuOaXut/RgRjKNeqQura1zeYF+tSLSlWDc0rDBOrEpwD/1EOpKVCbgtl8ke7f4oinLfgBNk4HcwqaQUYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "idb": "^7.1.1",
+        "nanoid": "^5.0.1",
+        "y-provider": "0.10.0-canary.9"
+      },
+      "peerDependencies": {
+        "yjs": "^13"
+      }
+    },
+    "node_modules/@toeverything/y-indexeddb/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@ts-gql/tag": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@ts-gql/tag/-/tag-0.7.3.tgz",
+      "integrity": "sha512-qWBoe5TGXs7l6lrdSfqAhsZP1aW9vEoZvjy5hPsiMwQ7VB8PyK2TFmLCijLmdeKSiY7BSzff20xZZrLIMB+IKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "graphql-tag": "^2.12.6"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || 14 || 15 || 16"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -2072,6 +5266,36 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/is-hotkey": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.10.tgz",
+      "integrity": "sha512-RvC8KMw5BCac1NvRRyaHgMMEtBaZ6wh0pyPTBu7izn4Sj/AX9Y4aXU5c7rX8PnM/knsuUpC1IeoBkANtxBypsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2080,6 +5304,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
@@ -2111,6 +5342,30 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/sax": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
@@ -2131,6 +5386,76 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@urql/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.13",
+        "wonka": "^6.3.2"
+      }
+    },
+    "node_modules/@urql/exchange-auth": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-auth/-/exchange-auth-2.2.1.tgz",
+      "integrity": "sha512-n4xUxxjvY36GJh539sLaPFyvFzreADOv8EFQdTiXOCIRVoXXhWVVI7DjY/HNtLICfbg1+UlbvQ7sNkwaBouDHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@urql/core": "^5.1.1",
+        "wonka": "^6.3.2"
+      },
+      "peerDependencies": {
+        "@urql/core": "^5.0.0"
+      }
+    },
+    "node_modules/@urql/exchange-graphcache": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-graphcache/-/exchange-graphcache-7.2.4.tgz",
+      "integrity": "sha512-kiKbT0ZrtyQmmgNLYR0qkZAJjWHQOtrd+6Dt9JMtm3L/A8r3D6ptcJn668BADP6J+vkxcfNFtdI+0OdmBBkRgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.13",
+        "@urql/core": "^5.1.2",
+        "wonka": "^6.3.2"
+      },
+      "peerDependencies": {
+        "@urql/core": "^5.0.0"
+      }
+    },
+    "node_modules/@urql/exchange-persisted": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-persisted/-/exchange-persisted-4.3.1.tgz",
+      "integrity": "sha512-VRGYFNW0gaT7+VCR/1rCMWEP9gvnDnlAolKisysLYkv8Zeysbqx+Omw4IgIRCLjI6oHWPkH8zOhFbqA3GRQ9HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@urql/core": "^5.1.1",
+        "wonka": "^6.3.2"
+      },
+      "peerDependencies": {
+        "@urql/core": "^5.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -2289,6 +5614,18 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -2467,6 +5804,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -2477,11 +5829,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
     "node_modules/base-64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -2544,6 +5914,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
@@ -2579,6 +5991,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -2590,6 +6011,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -2810,6 +6251,18 @@
       "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
       "license": "ISC"
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -2835,6 +6288,31 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2946,6 +6424,12 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2975,6 +6459,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -3042,9 +6532,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
+      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -3067,6 +6557,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/direction": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dlv": {
@@ -3168,6 +6671,18 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.335",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
+      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
+      "license": "ISC"
+    },
+    "node_modules/emery": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/emery/-/emery-1.4.4.tgz",
+      "integrity": "sha512-mMoO3uGDoiw/DmZ/YekT9gEoC0IFAXNWzYVukY8+/j0Wt8un1IDraIYGx+cMbRh+fHaCDE6Ui7zFAN8ezZSsAA==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -3186,6 +6701,21 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
@@ -3193,6 +6723,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-module-lexer": {
@@ -3279,6 +6818,15 @@
         "@esbuild/win32-arm64": "0.25.12",
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3384,6 +6932,18 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -3424,11 +6984,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/facepaint": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/facepaint/-/facepaint-1.2.1.tgz",
+      "integrity": "sha512-oNvBekbhsm/0PNSOWca5raHNAi6dG960Bx6LJgxDPNF59WpuspgQ17bN5MKwOr7JcFdQYc7StW3VZ28DBZLavQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3482,6 +7047,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
     },
     "node_modules/flattie": {
       "version": "1.1.1",
@@ -3590,6 +7161,24 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
@@ -3674,6 +7263,30 @@
         "process": "^0.11.10"
       }
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/h3": {
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
@@ -3714,6 +7327,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -3986,6 +7611,27 @@
         "npm": ">=1.3.7"
       }
     },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
@@ -3997,6 +7643,32 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/import-meta-resolve": {
@@ -4014,6 +7686,18 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/ip-regex": {
       "version": "1.0.3",
@@ -4063,6 +7747,21 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-decimal": {
       "version": "2.0.1",
@@ -4115,6 +7814,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-hotkey": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
+      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw==",
+      "license": "MIT"
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -4145,6 +7850,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -4173,6 +7887,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     },
     "node_modules/isstream": {
       "version": "0.1.2",
@@ -4256,6 +7980,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -4273,6 +8003,24 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json-schema": {
@@ -4295,6 +8043,18 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
@@ -4320,6 +8080,33 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
     },
     "node_modules/load-bmfont": {
       "version": "1.4.2",
@@ -4350,6 +8137,18 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.deburr": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+      "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -4410,6 +8209,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/match-sorter": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.4.tgz",
+      "integrity": "sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.8",
+        "remove-accents": "0.5.0"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -6043,6 +9852,12 @@
       "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "license": "MIT"
     },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "license": "MIT"
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -6118,6 +9933,12 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
@@ -6173,6 +9994,18 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parse-bmfont-ascii": {
       "version": "1.0.6",
@@ -6231,6 +10064,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -6274,6 +10125,15 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/partysocket": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-0.0.22.tgz",
+      "integrity": "sha512-HmFJoVA48vfU5VaQ539YnQt+/QncV5wdlN7vEW//m8eCnOV2PKB8X08c7hI4VLrqntajaWovHhprWHgXbXgR1A==",
+      "license": "ISC",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6283,6 +10143,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "2.0.1",
@@ -6306,6 +10172,15 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -6474,6 +10349,92 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -6512,6 +10473,36 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/read-chunk": {
       "version": "1.0.1",
@@ -6798,6 +10789,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
+    },
     "node_modules/request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -6845,6 +10842,36 @@
         "jpeg-js": "^0.1.1",
         "parse-png": "^1.1.1"
       },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -6954,6 +10981,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6991,6 +11024,21 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -7002,6 +11050,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -7139,6 +11193,72 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "license": "MIT"
+    },
+    "node_modules/slate": {
+      "version": "0.91.4",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.91.4.tgz",
+      "integrity": "sha512-aUJ3rpjrdi5SbJ5G1Qjr3arytfRkEStTmHjBfWq2A2Q8MybacIzkScSvGJjQkdTk3djCK9C9SEOt39sSeZFwTw==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^9.0.6",
+        "is-plain-object": "^5.0.0",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "node_modules/slate-history": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.86.0.tgz",
+      "integrity": "sha512-OxObL9tbhgwvSlnKSCpGIh7wnuaqvOj5jRExGjEyCU2Ke8ctf22HjT+jw7GEi9ttLzNTUmTEU3YIzqKGeqN+og==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^5.0.0"
+      },
+      "peerDependencies": {
+        "slate": ">=0.65.3"
+      }
+    },
+    "node_modules/slate-react": {
+      "version": "0.91.11",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.91.11.tgz",
+      "integrity": "sha512-2nS29rc2kuTTJrEUOXGyTkFATmTEw/R9KuUXadUYiz+UVwuFOUMnBKuwJWyuIBOsFipS+06SkIayEf5CKdARRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "@types/is-hotkey": "^0.1.1",
+        "@types/lodash": "^4.14.149",
+        "direction": "^1.0.3",
+        "is-hotkey": "^0.1.6",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.4",
+        "scroll-into-view-if-needed": "^2.2.20",
+        "tiny-invariant": "1.0.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "slate": ">=0.65.3"
+      }
+    },
+    "node_modules/slate-react/node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==",
+      "license": "MIT"
+    },
+    "node_modules/slate-react/node_modules/is-hotkey": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.8.tgz",
+      "integrity": "sha512-qs3NZ1INIS+H+yeo7cD9pDfwYV/jqRh1JG9S9zYrNudkoUQg7OL7ziXqRKu+InFjUIDoP2o6HIkLYMh1pcWgyQ==",
+      "license": "MIT"
+    },
+    "node_modules/slate-react/node_modules/scroll-into-view-if-needed": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
+      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^1.0.20"
+      }
     },
     "node_modules/smol-toml": {
       "version": "1.6.0",
@@ -7321,6 +11441,21 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/superstruct": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -7331,6 +11466,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/svgo": {
@@ -7358,10 +11505,28 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
     "node_modules/tinycolor2": {
@@ -7471,8 +11636,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -7824,6 +11988,36 @@
         }
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -7845,6 +12039,29 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/urql": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/urql/-/urql-4.2.2.tgz",
+      "integrity": "sha512-3GgqNa6iF7bC4hY/ImJKN4REQILcSU9VKcKL8gfELZM8mM5BnLH1BsCc8kBdnVGD1LIFOs4W3O2idNHhON1r0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@urql/core": "^5.1.1",
+        "wonka": "^6.3.2"
+      },
+      "peerDependencies": {
+        "@urql/core": "^5.0.0",
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/uuid": {
@@ -8008,6 +12225,12 @@
         }
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -8057,6 +12280,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/wonka": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.6.tgz",
+      "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
+      "license": "MIT"
     },
     "node_modules/workerd": {
       "version": "1.20251118.0",
@@ -8650,6 +12879,81 @@
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
     },
+    "node_modules/y-prosemirror": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
+      "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.109"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/y-provider": {
+      "version": "0.10.0-canary.9",
+      "resolved": "https://registry.npmjs.org/y-provider/-/y-provider-0.10.0-canary.9.tgz",
+      "integrity": "sha512-ImkLqCpxHK0lkxD12s7BE4p14NiAnQQSJGN5GONl4W4CyLBx6+tRop3yg66abg64N3JYX9EwXxnIVDziq6b8Dw==",
+      "peerDependencies": {
+        "yjs": "^13"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -8657,6 +12961,23 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.30",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
+      "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,16 @@
   "dependencies": {
     "@astrojs/cloudflare": "^12.6.12",
     "@astrojs/mdx": "^4.3.13",
+    "@astrojs/react": "^5.0.3",
     "@astrojs/rss": "^4.0.15",
     "@astrojs/sitemap": "^3.7.0",
-    "astro": "^5.17.1"
+    "@keystatic/astro": "^5.0.6",
+    "@keystatic/core": "^0.5.50",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "astro": "^5.17.1",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
   },
   "devDependencies": {
     "@resvg/resvg-js": "^2.6.2",

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Layout from '../layouts/Layout.astro';
 ---
 

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import { getCollection } from 'astro:content';
 import type { GetStaticPaths } from 'astro';
 import Layout from '../../layouts/Layout.astro';

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import { getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Layout from '../layouts/Layout.astro';
 import { getCollection, getEntry } from 'astro:content';
 

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Layout from '../layouts/Layout.astro';
 
 const lastUpdated = '2026年3月25日';

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,3 +1,4 @@
+export const prerender = true;
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';

--- a/tools/blog-editor/server.py
+++ b/tools/blog-editor/server.py
@@ -136,6 +136,11 @@ def convert_node(node) -> str:
         href = node.get("href", "")
         return f"[{inner()}]({href})"
 
+    if tag == "img":
+        src = node.get("src", "")
+        alt = node.get("alt", "")
+        return f"![{alt}]({src})"
+
     if tag == "br":
         return "\n"
 
@@ -172,6 +177,23 @@ def convert_node(node) -> str:
         return content
 
     if tag in ("div", "body", "html", "section", "article", "[document]"):
+        # TipTap カスタムブロック → MDX コンポーネントに逆変換
+        data_node = node.get("data-node", "")
+        if data_node == "note":
+            note_type = node.get("data-type", "info")
+            note_title = node.get("data-title", "")
+            content_div = node.find("div", class_="note-node-content") or node
+            inner_content = "".join(convert_node(c) for c in content_div.children).strip()
+            title_attr = f' title="{note_title}"' if note_title else ''
+            return f'<Note type="{note_type}"{title_attr}>\n{inner_content}\n</Note>\n\n'
+        if data_node == "link-card":
+            url = node.get("data-url", "")
+            return f'<LinkCard url="{url}" />\n\n'
+        if data_node == "details":
+            summary = node.get("data-summary", "詳細を見る")
+            content_div = node.find("div", class_="details-node-content") or node
+            inner_content = "".join(convert_node(c) for c in content_div.children).strip()
+            return f'<Details summary="{summary}">\n{inner_content}\n</Details>\n\n'
         return inner()
 
     # 未知のタグ → 生のHTMLとして通す（MDXコンポーネント等）
@@ -197,20 +219,64 @@ def inline_md_to_html(text: str) -> str:
     text = re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"<em>\1</em>", text)
     # 取り消し線
     text = re.sub(r"~~(.+?)~~", r"<s>\1</s>", text)
+    # 画像（リンクより先に処理すること）
+    text = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", r'<img src="\2" alt="\1">', text)
     # リンク
     text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', text)
-    # <mark> → Quill の background-color span に変換
-    text = re.sub(
-        r'<mark style="background-color:([^"]+)">(.*?)</mark>',
-        r'<span style="background-color:\1">\2</span>',
-        text, flags=re.DOTALL,
-    )
+    # <mark> はTipTap Highlight 拡張がそのまま解釈できるので変換しない
     return text
 
 
-def markdown_to_quill_html(md: str) -> str:
-    """ブログ記事の Markdown+HTML を Quill が読み込める HTML に変換"""
+def _mdx_component_to_editor_html(mdx: str) -> str:
+    """単一の MDX コンポーネントブロックをTipTapカスタムノードHTMLに変換"""
+    s = mdx.strip()
+    # Note
+    note_m = re.match(r'<Note\s+([^>]+?)>([\s\S]*?)</Note>', s, re.DOTALL)
+    if note_m:
+        attrs_str = note_m.group(1)
+        content = note_m.group(2).strip()
+        type_m  = re.search(r'type=["\']([^"\']+)["\']', attrs_str)
+        title_m = re.search(r'title=["\']([^"\']+)["\']', attrs_str)
+        note_type  = type_m.group(1)  if type_m  else 'info'
+        note_title = html_lib.escape(title_m.group(1) if title_m else '')
+        content_html = markdown_to_editor_html(content)
+        return (f'<div data-node="note" data-type="{note_type}" data-title="{note_title}">'
+                f'<div class="note-node-content">{content_html}</div></div>')
+    # LinkCard
+    link_m = re.match(r'<LinkCard\s+url=["\']([^"\']+)["\']', s)
+    if link_m:
+        url = html_lib.escape(link_m.group(1))
+        return f'<div data-node="link-card" data-url="{url}"></div>'
+    # Details
+    details_m = re.match(r'<Details\s+summary=["\']([^"\']+)["\']>([\s\S]*?)</Details>', s, re.DOTALL)
+    if details_m:
+        summary = html_lib.escape(details_m.group(1))
+        content = details_m.group(2).strip()
+        content_html = markdown_to_editor_html(content)
+        return (f'<div data-node="details" data-summary="{summary}">'
+                f'<div class="details-node-content">{content_html}</div></div>')
+    # その他 MDX コンポーネント（RakutenAffiliate 等）→ コードブロックとして保護
+    return f'<pre><code>{html_lib.escape(s)}</code></pre>'
+
+
+def markdown_to_editor_html(md: str) -> str:
+    """ブログ記事の Markdown+MDX を TipTap が読み込める HTML に変換"""
     md = md.replace("\r\n", "\n").replace("\r", "\n")
+
+    # 複数行にまたがる MDX コンポーネントを先にプレースホルダで保護
+    _placeholders: dict[str, str] = {}
+    _counter = [0]
+
+    def _store(m):
+        key = f"\x00MDX{_counter[0]}\x00"
+        _placeholders[key] = m.group(0)
+        _counter[0] += 1
+        return key
+
+    md = re.sub(r'<Note\s[^>]*?>[\s\S]*?</Note>',    _store, md, flags=re.DOTALL)
+    md = re.sub(r'<Details\s[^>]*?>[\s\S]*?</Details>', _store, md, flags=re.DOTALL)
+    md = re.sub(r'<RakutenAffiliate\s[^/]*/?>',        _store, md, flags=re.DOTALL)
+
     raw_blocks = re.split(r"\n{2,}", md.strip())
     html_parts = []
 
@@ -219,11 +285,18 @@ def markdown_to_quill_html(md: str) -> str:
         if not block:
             continue
 
+        # プレースホルダを復元して変換
+        if block in _placeholders:
+            html_parts.append(_mdx_component_to_editor_html(_placeholders[block]))
+            continue
+
         # コードブロック
         cb_m = re.match(r"^```(\w*)\n?([\s\S]*?)```$", block, re.DOTALL)
         if cb_m:
-            code = cb_m.group(2).rstrip("\n")
-            html_parts.append(f'<pre class="ql-syntax" spellcheck="false">{code}</pre>')
+            lang = cb_m.group(1)
+            code = html_lib.escape(cb_m.group(2).rstrip("\n"))
+            lang_cls = f' class="language-{lang}"' if lang else ''
+            html_parts.append(f'<pre><code{lang_cls}>{code}</code></pre>')
             continue
 
         # 見出し
@@ -235,7 +308,7 @@ def markdown_to_quill_html(md: str) -> str:
 
         # HR
         if re.match(r"^[-*_]{3,}$", block.strip()):
-            html_parts.append("<p><br></p>")
+            html_parts.append("<hr>")
             continue
 
         lines = block.split("\n")
@@ -266,9 +339,14 @@ def markdown_to_quill_html(md: str) -> str:
             html_parts.append(f"<blockquote><p>{inner}</p></blockquote>")
             continue
 
-        # MDXコンポーネント（<LinkCard />, <Details> 等）→ コードブロックとして保護
+        # 単行 MDX コンポーネント（<LinkCard /> 等）→ カスタムノード or コードブロック
         if re.match(r'^<[A-Z][a-zA-Z]*[\s/>]', block.strip()):
-            html_parts.append(f'<pre class="ql-syntax" spellcheck="false">{html_lib.escape(block.strip())}</pre>')
+            html_parts.append(_mdx_component_to_editor_html(block.strip()))
+            continue
+
+        # export const（MDXトップレベルJS宣言）→ コードブロックとして保護
+        if block.strip().startswith("export "):
+            html_parts.append(f'<pre><code>{html_lib.escape(block.strip())}</code></pre>')
             continue
 
         # 通常段落（インラインHTMLも含む）
@@ -276,6 +354,10 @@ def markdown_to_quill_html(md: str) -> str:
         html_parts.append(f"<p>{converted}</p>")
 
     return "\n".join(html_parts)
+
+
+# 後方互換エイリアス
+markdown_to_quill_html = markdown_to_editor_html
 
 
 # ── Frontmatter ───────────────────────────────────────────────────────────
@@ -355,7 +437,7 @@ def get_template():
     _, body = parse_frontmatter(raw)
     # HTML コメント除去（テンプレートの説明コメントは不要）
     body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
-    body_html = markdown_to_quill_html(body.strip())
+    body_html = markdown_to_editor_html(body.strip())
     return jsonify({"bodyHtml": body_html, "success": True})
 
 
@@ -553,7 +635,7 @@ def load_post():
     fm, body = parse_frontmatter(raw)
     ext = "mdx" if rel_path.endswith(".mdx") else "md"
 
-    # MDX: 先頭の import 行を分離
+    # MDX: 先頭の import / export const 行を分離（importsエリアに表示）
     imports = ""
     if ext == "mdx":
         import_lines = []
@@ -561,8 +643,10 @@ def load_post():
         rest = []
         in_imports = True
         for line in body_lines:
-            if in_imports and (line.startswith("import ") or line.strip() == ""):
-                if line.startswith("import "):
+            is_import = line.startswith("import ") or line.startswith("export ")
+            is_empty  = line.strip() == ""
+            if in_imports and (is_import or is_empty):
+                if is_import:
                     import_lines.append(line)
             else:
                 in_imports = False
@@ -570,7 +654,7 @@ def load_post():
         imports = "\n".join(import_lines)
         body = "\n".join(rest)
 
-    body_html = markdown_to_quill_html(body.strip())
+    body_html = markdown_to_editor_html(body.strip())
 
     return jsonify({
         "success": True,

--- a/tools/blog-editor/templates/editor.html
+++ b/tools/blog-editor/templates/editor.html
@@ -10,7 +10,6 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Blog Editor">
   <link rel="apple-touch-icon" href="/static/icon-192.png">
-  <link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet">
   <style>
     :root {
       --bg: #0d0d0d;
@@ -37,14 +36,10 @@
       --red: #cc2200;
     }
     body.light header h1 { color: #111111; }
-    body.light .ql-snow .ql-stroke { stroke: #555; }
-    body.light .ql-snow .ql-fill   { fill:   #555; }
-    body.light .ql-snow .ql-picker { color:  #555; }
-    body.light .ql-toolbar.ql-snow button:hover .ql-stroke,
-    body.light .ql-toolbar.ql-snow button.ql-active .ql-stroke { stroke: #b8860b; }
-    body.light .ql-toolbar.ql-snow button:hover .ql-fill,
-    body.light .ql-toolbar.ql-snow button.ql-active .ql-fill   { fill:   #b8860b; }
-    body.light .ql-editor a { color: #b8860b; }
+    body.light .tb-btn { color: #555; }
+    body.light .tb-btn:hover, body.light .tb-btn.is-active { color: #b8860b; background: rgba(184,134,11,0.08); }
+    body.light #tb-heading { background: #fff; color: #555; border-color: #ddd8c0; }
+    body.light .tiptap a { color: #b8860b; }
     body.light .fm-draft .tooltip { background: #fff; color: #333; border-color: #ddd8c0; }
     body.light .fm-toggle-bar:hover { background: rgba(0,0,0,0.04); }
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -218,27 +213,194 @@
     }
     .psep { width: 1px; height: 13px; background: var(--border); margin: 0 3px; flex-shrink: 0; }
 
-    /* ── Editor ── */
+    /* ── Editor Toolbar ── */
+    #editor-toolbar {
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 4px 8px;
+      display: flex;
+      align-items: center;
+      gap: 1px;
+      flex-shrink: 0;
+      flex-wrap: wrap;
+    }
+    #tb-heading {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text);
+      padding: 2px 4px;
+      border-radius: 3px;
+      font-size: 12px;
+      cursor: pointer;
+      height: 24px;
+    }
+    #tb-heading:focus { outline: none; border-color: var(--yellow); }
+    .tb-btn {
+      background: none;
+      border: 1px solid transparent;
+      color: #888;
+      cursor: pointer;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-size: 13px;
+      height: 24px;
+      min-width: 24px;
+      transition: all 0.1s;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-family: inherit;
+    }
+    .tb-btn:hover { color: var(--yellow); background: rgba(255,215,0,0.08); border-color: transparent; }
+    .tb-btn.is-active { color: var(--yellow); background: rgba(255,215,0,0.12); }
+    .tb-italic { font-style: italic; }
+    .tb-underline { text-decoration: underline; }
+    .tb-strike { text-decoration: line-through; }
+    .tb-sep { width: 1px; height: 16px; background: var(--border); margin: 0 4px; flex-shrink: 0; }
+
+    /* ── TipTap Editor ── */
     .editor-wrap { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
-    #editor { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
-    .ql-toolbar.ql-snow { background: var(--surface); border: none; border-bottom: 1px solid var(--border); padding: 4px 8px; flex-shrink: 0; }
-    .ql-container.ql-snow { flex: 1; border: none; background: var(--bg); overflow: auto; }
-    .ql-editor { color: var(--text); font-size: 15px; line-height: 1.85; min-height: 100%; padding: 18px 22px; }
-    .ql-editor.ql-blank::before { color: var(--muted); font-style: normal; font-size: 14px; }
-    .ql-snow .ql-stroke { stroke: #888; }
-    .ql-snow .ql-fill { fill: #888; }
-    .ql-snow .ql-picker { color: #888; }
-    .ql-snow .ql-picker-options { background: var(--surface); border-color: var(--border); }
-    .ql-snow .ql-picker-item { color: var(--text); }
-    .ql-snow .ql-picker-item:hover, .ql-snow .ql-picker-item.ql-selected { color: var(--yellow); }
-    .ql-snow .ql-picker-label:hover, .ql-snow .ql-picker-label.ql-active { color: var(--yellow); }
-    .ql-toolbar.ql-snow button:hover .ql-stroke, .ql-toolbar.ql-snow button.ql-active .ql-stroke { stroke: var(--yellow); }
-    .ql-toolbar.ql-snow button:hover .ql-fill, .ql-toolbar.ql-snow button.ql-active .ql-fill { fill: var(--yellow); }
-    .ql-editor u { text-decoration: underline; }
-    .ql-editor s { text-decoration: line-through; }
-    .ql-editor blockquote { border-left: 3px solid var(--yellow); padding-left: 12px; color: var(--muted); }
-    .ql-editor pre.ql-syntax { background: var(--surface); border: 1px solid var(--border); border-radius: 4px; color: var(--green); font-size: 13px; }
-    .ql-editor a { color: var(--yellow); }
+    #editor { flex: 1; overflow: auto; background: var(--bg); }
+    .tiptap {
+      color: var(--text);
+      font-size: 15px;
+      line-height: 1.85;
+      min-height: 100%;
+      padding: 18px 22px;
+      outline: none;
+    }
+    .tiptap p.is-editor-empty:first-child::before {
+      content: attr(data-placeholder);
+      color: var(--muted);
+      font-size: 14px;
+      pointer-events: none;
+      float: left;
+      height: 0;
+    }
+    .tiptap u { text-decoration: underline; }
+    .tiptap s { text-decoration: line-through; }
+    .tiptap em { font-style: italic; }
+    .tiptap blockquote { border-left: 3px solid var(--yellow); padding-left: 12px; color: var(--muted); margin: 0.5em 0; }
+    .tiptap pre { background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 10px 14px; margin: 0.5em 0; }
+    .tiptap pre code { color: var(--green); font-size: 13px; font-family: 'Courier New', monospace; background: none; padding: 0; }
+    .tiptap a { color: var(--yellow); }
+    .tiptap code { background: var(--surface); padding: 1px 4px; border-radius: 3px; font-size: 0.9em; font-family: 'Courier New', monospace; }
+    .tiptap h1 { font-size: 1.6em; margin: 0.6em 0 0.3em; }
+    .tiptap h2 { font-size: 1.4em; margin: 0.6em 0 0.3em; }
+    .tiptap h3 { font-size: 1.2em; margin: 0.5em 0 0.25em; }
+    .tiptap ul, .tiptap ol { padding-left: 1.5em; margin: 0.25em 0; }
+    .tiptap li { margin-bottom: 0.2em; }
+    .tiptap mark { border-radius: 3px; padding: 1px 2px; }
+    .tiptap hr { border: none; border-top: 1px solid var(--border); margin: 1.5em 0; }
+    .tiptap p { margin-bottom: 0.5em; }
+    .tiptap p:last-child { margin-bottom: 0; }
+
+    /* ── Custom Nodes ── */
+    .note-node {
+      border-left: 4px solid #111;
+      border-radius: 0 6px 6px 0;
+      margin: 1rem 0;
+      background: rgba(0,0,0,0.04);
+      overflow: hidden;
+    }
+    .note-node-info    { border-color: #111111; background: rgba(0,0,0,0.04); }
+    .note-node-warning { border-color: #eab308; background: rgba(234,179,8,0.08); }
+    .note-node-tip     { border-color: #22c55e; background: rgba(34,197,94,0.08); }
+    .note-node-danger  { border-color: #ef4444; background: rgba(239,68,68,0.08); }
+    .note-node-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 5px 10px;
+      background: rgba(0,0,0,0.06);
+      border-bottom: 1px solid rgba(255,255,255,0.05);
+    }
+    .note-type-select {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text);
+      padding: 1px 4px;
+      border-radius: 3px;
+      font-size: 11px;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    .note-title-input, .details-summary-input {
+      flex: 1;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text);
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-size: 12px;
+    }
+    .note-title-input:focus, .details-summary-input:focus, .link-card-url-input:focus {
+      outline: none; border-color: var(--yellow);
+    }
+    .node-del-btn {
+      background: none;
+      border: none;
+      color: var(--muted);
+      cursor: pointer;
+      font-size: 14px;
+      padding: 0 2px;
+      opacity: 0.5;
+      flex-shrink: 0;
+      line-height: 1;
+    }
+    .node-del-btn:hover { opacity: 1; color: var(--red); }
+    .note-node-content { padding: 8px 12px; }
+    .note-node-content > * { margin-bottom: 0.5em; }
+
+    .link-card-node {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 10px 12px;
+      margin: 1rem 0;
+      background: var(--surface);
+      position: relative;
+    }
+    .link-card-node-header {
+      font-size: 11px;
+      color: var(--muted);
+      margin-bottom: 6px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .link-card-url-input {
+      width: calc(100% - 28px);
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text);
+      padding: 4px 8px;
+      border-radius: 3px;
+      font-size: 12px;
+      font-family: 'Courier New', monospace;
+    }
+    .link-card-node .node-del-btn {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+    }
+
+    .details-node {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      margin: 1rem 0;
+      overflow: hidden;
+      background: var(--surface);
+    }
+    .details-node-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      background: var(--surface2);
+      border-bottom: 1px solid var(--border);
+    }
+    .details-node-header::before { content: '▶'; font-size: 11px; color: var(--muted); flex-shrink: 0; }
+    .details-node-content { padding: 8px 12px; }
+    .details-node-content > * { margin-bottom: 0.5em; }
 
     /* ── Preview ── */
     .preview-header {
@@ -529,33 +691,22 @@
 
     /* ── Mobile ── */
     @media (max-width: 640px) {
-      /* ヘッダー */
       header { padding: 7px 10px; gap: 6px; flex-wrap: wrap; }
       header h1 { font-size: 13px; }
       .header-btn { padding: 5px 8px; font-size: 11px; }
       .ext-toggle { margin-left: 0; }
       .ext-btn { padding: 5px 8px; font-size: 11px; }
-
-      /* レイアウト: 右ペイン（プレビュー）を非表示 */
       .right-pane { display: none; }
       .left-pane { width: 100%; border-right: none; }
-
-      /* フロントマター: 1カラムに */
       .fm-grid { grid-template-columns: 1fr; }
       .fm-grid .span2 { grid-column: 1; }
       .fm-bottom-row { flex-direction: column; align-items: flex-start; gap: 6px; }
       .fm-field[style] { flex: unset !important; width: 100% !important; margin-left: 0 !important; }
-
-      /* ボトムバー: save-path を非表示 */
       #save-path { display: none; }
       .bottom-bar { gap: 6px; }
       .save-btn { padding: 6px 16px; }
       .publish-btn { padding: 6px 10px; font-size: 12px; }
-
-      /* OGP Toast */
       #ogp-toast { width: calc(100vw - 32px); right: 16px; }
-
-      /* モーダルボタンを縦並びに */
       .modal-actions { flex-wrap: wrap; }
       .modal-actions button { flex: 1 1 auto; text-align: center; }
     }
@@ -669,8 +820,36 @@
       <div class="color-dot clear" title="背景なし" onclick="applyBg(false)">✕</div>
     </div>
 
-    <!-- Quill -->
+    <!-- TipTap Editor -->
     <div class="editor-wrap">
+      <!-- Toolbar -->
+      <div id="editor-toolbar">
+        <select id="tb-heading" title="見出し" onchange="applyHeading(this.value)">
+          <option value="0">本文</option>
+          <option value="1">H1</option>
+          <option value="2">H2</option>
+          <option value="3">H3</option>
+        </select>
+        <span class="tb-sep"></span>
+        <button class="tb-btn" data-cmd="bold"        title="太字 (Ctrl+B)"><strong>B</strong></button>
+        <button class="tb-btn tb-italic" data-cmd="italic"      title="斜体 (Ctrl+I)">I</button>
+        <button class="tb-btn tb-underline" data-cmd="underline"   title="下線 (Ctrl+U)">U</button>
+        <button class="tb-btn tb-strike" data-cmd="strike"      title="取り消し線">S</button>
+        <span class="tb-sep"></span>
+        <button class="tb-btn" data-cmd="link"        title="リンク" onclick="editorLink()">🔗</button>
+        <button class="tb-btn" data-cmd="blockquote"  title="引用">❝</button>
+        <button class="tb-btn" data-cmd="codeBlock"   title="コードブロック" style="font-family:monospace">&lt;/&gt;</button>
+        <span class="tb-sep"></span>
+        <button class="tb-btn" data-cmd="bulletList"  title="箇条書き">•≡</button>
+        <button class="tb-btn" data-cmd="orderedList" title="番号付き">1.≡</button>
+        <button class="tb-btn" data-cmd="horizontalRule" title="区切り線">──</button>
+        <span class="tb-sep"></span>
+        <button class="tb-btn" data-cmd="undo"        title="元に戻す (Ctrl+Z)">↩</button>
+        <button class="tb-btn" data-cmd="redo"        title="やり直し (Ctrl+Y)">↪</button>
+        <span class="tb-sep"></span>
+        <button class="tb-btn" data-cmd="clear"       title="書式をクリア">✕</button>
+      </div>
+      <!-- Editor mount point -->
       <div id="editor"></div>
     </div>
 
@@ -751,86 +930,326 @@
   <div class="tweet-drawer-body" id="tweet-drawer-body"></div>
 </div>
 
-<script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
-<script>
+<!-- ── TipTap (via esm.sh CDN) ── -->
+<script type="module">
+import { Editor, Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@2.11.5';
+import StarterKit              from 'https://esm.sh/@tiptap/starter-kit@2.11.5';
+import Underline               from 'https://esm.sh/@tiptap/extension-underline@2.11.5';
+import TextStyle               from 'https://esm.sh/@tiptap/extension-text-style@2.11.5';
+import { Color }               from 'https://esm.sh/@tiptap/extension-color@2.11.5';
+import Highlight               from 'https://esm.sh/@tiptap/extension-highlight@2.11.5';
+import Link                    from 'https://esm.sh/@tiptap/extension-link@2.11.5';
+import Placeholder             from 'https://esm.sh/@tiptap/extension-placeholder@2.11.5';
+import Image                   from 'https://esm.sh/@tiptap/extension-image@2.11.5';
 
-// ── Quill ──────────────────────────────────────────────────────────────────
-const PRESET_COLORS = [
-  '#ff0000','#ff007d','#ff7f00','#ffd700','#7cd300',
-  '#0000ff','#8f20ff','#00ccff','#ffffff','#e0e0e0','#888','#000','#ffcc00',
-];
-const quill = new Quill('#editor', {
-  theme: 'snow',
-  placeholder: 'どうも、レイと申します。\n\n本文を書いてください...',
-  modules: {
-    toolbar: [
-      [{ header: [1, 2, 3, false] }],
-      ['bold', 'italic', 'underline', 'strike'],
-      [{ color: PRESET_COLORS }, { background: PRESET_COLORS }],
-      ['link', 'blockquote', 'code-block'],
-      [{ list: 'ordered' }, { list: 'bullet' }],
-      ['clean'],
-    ]
-  }
+// ── カスタムノード: Note ───────────────────────────────────────────────────────
+const NoteBlock = Node.create({
+  name: 'noteBlock',
+  group: 'block',
+  content: 'block+',
+  defining: true,
+  isolating: true,
+  addAttributes() {
+    return {
+      type:  { default: 'info',  parseHTML: el => el.getAttribute('data-type'),  renderHTML: a => ({ 'data-type': a.type })  },
+      title: { default: '',      parseHTML: el => el.getAttribute('data-title'), renderHTML: a => ({ 'data-title': a.title }) },
+    };
+  },
+  parseHTML() { return [{ tag: 'div[data-node="note"]' }]; },
+  renderHTML({ node, HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-node': 'note' }), 0];
+  },
+  addNodeView() {
+    return ({ node, getPos, editor }) => {
+      const dom = document.createElement('div');
+      dom.className = `note-node note-node-${node.attrs.type}`;
+      dom.setAttribute('data-node', 'note');
+
+      const header = document.createElement('div');
+      header.className = 'note-node-header';
+      header.contentEditable = 'false';
+
+      const typeSelect = document.createElement('select');
+      typeSelect.className = 'note-type-select';
+      const typeLabels = { info: 'ℹ info', warning: '⚠ warning', tip: '💡 tip', danger: '🚨 danger' };
+      for (const [val, label] of Object.entries(typeLabels)) {
+        const opt = document.createElement('option');
+        opt.value = val; opt.textContent = label; opt.selected = node.attrs.type === val;
+        typeSelect.appendChild(opt);
+      }
+      typeSelect.addEventListener('change', () => {
+        const pos = typeof getPos === 'function' ? getPos() : null;
+        if (pos !== null) editor.view.dispatch(editor.view.state.tr.setNodeMarkup(pos, undefined, { ...node.attrs, type: typeSelect.value }));
+        dom.className = `note-node note-node-${typeSelect.value}`;
+      });
+
+      const titleInput = document.createElement('input');
+      titleInput.className = 'note-title-input';
+      titleInput.placeholder = 'タイトル（省略可）';
+      titleInput.value = node.attrs.title;
+      titleInput.addEventListener('input', () => {
+        const pos = typeof getPos === 'function' ? getPos() : null;
+        if (pos !== null) editor.view.dispatch(editor.view.state.tr.setNodeMarkup(pos, undefined, { ...node.attrs, title: titleInput.value }));
+      });
+
+      const delBtn = document.createElement('button');
+      delBtn.className = 'node-del-btn'; delBtn.textContent = '✕'; delBtn.title = '削除';
+      delBtn.addEventListener('click', () => {
+        const pos = typeof getPos === 'function' ? getPos() : null;
+        if (pos !== null) editor.view.dispatch(editor.view.state.tr.delete(pos, pos + node.nodeSize));
+      });
+
+      header.append(typeSelect, titleInput, delBtn);
+
+      const contentDOM = document.createElement('div');
+      contentDOM.className = 'note-node-content';
+
+      dom.append(header, contentDOM);
+      return { dom, contentDOM };
+    };
+  },
 });
 
-// ── 状態 ──────────────────────────────────────────────────────────────────
-let currentExt = 'md';
-let originalPath = '';   // 編集中の既存記事パス（新規なら空）
-let allPosts = [];       // 記事一覧キャッシュ
+// ── カスタムノード: LinkCard ──────────────────────────────────────────────────
+const LinkCardNode = Node.create({
+  name: 'linkCard',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return { url: { default: '', parseHTML: el => el.getAttribute('data-url'), renderHTML: a => ({ 'data-url': a.url }) } };
+  },
+  parseHTML() { return [{ tag: 'div[data-node="link-card"]' }]; },
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-node': 'link-card', class: 'link-card-node' })];
+  },
+  addNodeView() {
+    return ({ node, getPos, editor }) => {
+      const dom = document.createElement('div');
+      dom.className = 'link-card-node';
+      dom.setAttribute('data-node', 'link-card');
+      dom.contentEditable = 'false';
 
-// ── 拡張子切り替え ─────────────────────────────────────────────────────────
-function setExt(ext) {
-  currentExt = ext;
-  document.querySelectorAll('.ext-btn').forEach(b => b.classList.toggle('active', b.dataset.ext === ext));
-  document.getElementById('imports-section').classList.toggle('visible', ext === 'mdx');
+      const hdr = document.createElement('div');
+      hdr.className = 'link-card-node-header'; hdr.textContent = '🔗 LinkCard';
+
+      const urlInput = document.createElement('input');
+      urlInput.className = 'link-card-url-input';
+      urlInput.placeholder = 'URL を入力（例: https://example.com）';
+      urlInput.value = node.attrs.url;
+      urlInput.addEventListener('change', () => {
+        const pos = typeof getPos === 'function' ? getPos() : null;
+        if (pos !== null) editor.view.dispatch(editor.view.state.tr.setNodeMarkup(pos, undefined, { url: urlInput.value }));
+      });
+
+      const delBtn = document.createElement('button');
+      delBtn.className = 'node-del-btn'; delBtn.textContent = '✕'; delBtn.title = '削除';
+      delBtn.addEventListener('click', () => {
+        const pos = typeof getPos === 'function' ? getPos() : null;
+        if (pos !== null) editor.view.dispatch(editor.view.state.tr.delete(pos, pos + node.nodeSize));
+      });
+
+      dom.append(hdr, urlInput, delBtn);
+      return { dom };
+    };
+  },
+});
+
+// ── カスタムノード: Details ───────────────────────────────────────────────────
+const DetailsNode = Node.create({
+  name: 'detailsBlock',
+  group: 'block',
+  content: 'block+',
+  defining: true,
+  isolating: true,
+  addAttributes() {
+    return { summary: { default: '詳細を見る', parseHTML: el => el.getAttribute('data-summary'), renderHTML: a => ({ 'data-summary': a.summary }) } };
+  },
+  parseHTML() { return [{ tag: 'div[data-node="details"]' }]; },
+  renderHTML({ node, HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-node': 'details' }), 0];
+  },
+  addNodeView() {
+    return ({ node, getPos, editor }) => {
+      const dom = document.createElement('div');
+      dom.className = 'details-node';
+      dom.setAttribute('data-node', 'details');
+
+      const header = document.createElement('div');
+      header.className = 'details-node-header';
+      header.contentEditable = 'false';
+
+      const summaryInput = document.createElement('input');
+      summaryInput.className = 'details-summary-input';
+      summaryInput.placeholder = 'summary（折りたたみのタイトル）';
+      summaryInput.value = node.attrs.summary;
+      summaryInput.addEventListener('input', () => {
+        const pos = typeof getPos === 'function' ? getPos() : null;
+        if (pos !== null) editor.view.dispatch(editor.view.state.tr.setNodeMarkup(pos, undefined, { summary: summaryInput.value }));
+      });
+
+      const delBtn = document.createElement('button');
+      delBtn.className = 'node-del-btn'; delBtn.textContent = '✕'; delBtn.title = '削除';
+      delBtn.addEventListener('click', () => {
+        const pos = typeof getPos === 'function' ? getPos() : null;
+        if (pos !== null) editor.view.dispatch(editor.view.state.tr.delete(pos, pos + node.nodeSize));
+      });
+
+      header.append(summaryInput, delBtn);
+
+      const contentDOM = document.createElement('div');
+      contentDOM.className = 'details-node-content';
+
+      dom.append(header, contentDOM);
+      return { dom, contentDOM };
+    };
+  },
+});
+
+// ── Editor 初期化 ─────────────────────────────────────────────────────────────
+const editor = new Editor({
+  element: document.getElementById('editor'),
+  extensions: [
+    StarterKit.configure({ strike: {}, code: {}, codeBlock: {}, blockquote: {}, horizontalRule: {} }),
+    Underline,
+    TextStyle,
+    Color,
+    Highlight.configure({ multicolor: true }),
+    Link.configure({ openOnClick: false, HTMLAttributes: { rel: 'noopener noreferrer' } }),
+    Image.configure({ allowBase64: false, inline: false }),
+    Placeholder.configure({ placeholder: 'どうも、レイと申します。\n\n本文を書いてください...' }),
+    NoteBlock,
+    LinkCardNode,
+    DetailsNode,
+  ],
+  editorProps: {
+    attributes: { class: 'tiptap' },
+  },
+  onUpdate() { updateToolbarState(); },
+  onSelectionUpdate() { updateToolbarState(); },
+});
+
+// ── Toolbar 状態更新 ──────────────────────────────────────────────────────────
+function updateToolbarState() {
+  const cmds = ['bold','italic','underline','strike','blockquote','codeBlock','bulletList','orderedList'];
+  for (const cmd of cmds) {
+    const btn = document.querySelector(`.tb-btn[data-cmd="${cmd}"]`);
+    if (btn) btn.classList.toggle('is-active', editor.isActive(cmd));
+  }
+  let level = 0;
+  for (let i = 1; i <= 3; i++) {
+    if (editor.isActive('heading', { level: i })) { level = i; break; }
+  }
+  const sel = document.getElementById('tb-heading');
+  if (sel) sel.value = String(level);
 }
 
-// ── カラー適用 ─────────────────────────────────────────────────────────────
-function applyColor(c) { quill.format('color', c || false); }
-function applyBg(c)    { quill.format('background', c || false); }
+// ── Editor コマンド（グローバル公開）────────────────────────────────────────
+window.editorCmd = function(cmd) {
+  const c = editor.chain().focus();
+  switch (cmd) {
+    case 'bold':          c.toggleBold().run(); break;
+    case 'italic':        c.toggleItalic().run(); break;
+    case 'underline':     c.toggleUnderline().run(); break;
+    case 'strike':        c.toggleStrike().run(); break;
+    case 'blockquote':    c.toggleBlockquote().run(); break;
+    case 'codeBlock':     c.toggleCodeBlock().run(); break;
+    case 'bulletList':    c.toggleBulletList().run(); break;
+    case 'orderedList':   c.toggleOrderedList().run(); break;
+    case 'horizontalRule': c.setHorizontalRule().run(); break;
+    case 'undo':          c.undo().run(); break;
+    case 'redo':          c.redo().run(); break;
+    case 'clear':         c.clearNodes().unsetAllMarks().run(); break;
+  }
+};
 
-// ── MDX コンポーネントプリセット ───────────────────────────────────────────
+window.applyHeading = function(level) {
+  const lvl = parseInt(level);
+  if (lvl === 0) editor.chain().focus().setParagraph().run();
+  else           editor.chain().focus().toggleHeading({ level: lvl }).run();
+};
+
+window.editorLink = function() {
+  const current = editor.getAttributes('link').href || '';
+  const url = prompt('URL を入力してください:', current);
+  if (url === null) return;
+  if (url === '') editor.chain().focus().unsetLink().run();
+  else            editor.chain().focus().setLink({ href: url }).run();
+};
+
+window.applyColor = function(c) {
+  if (!c) editor.chain().focus().unsetColor().run();
+  else    editor.chain().focus().setColor(c).run();
+};
+
+window.applyBg = function(c) {
+  if (!c) editor.chain().focus().unsetHighlight().run();
+  else    editor.chain().focus().setHighlight({ color: c }).run();
+};
+
+// ── ツールバーボタンにイベント設定（data-cmd 属性を持つ、link は除く）────────
+document.querySelectorAll('.tb-btn[data-cmd]').forEach(btn => {
+  const cmd = btn.dataset.cmd;
+  if (cmd === 'link') return; // link は editorLink() で処理
+  btn.addEventListener('click', () => window.editorCmd(cmd));
+});
+
+// ── MDX コンポーネント挿入 ────────────────────────────────────────────────────
 const IMPORT_MAP = {
   Note:     "import Note from '@/components/blog/Note.astro';",
   LinkCard: "import LinkCard from '@/components/blog/LinkCard.astro';",
   Details:  "import Details from '@/components/blog/Details.astro';",
 };
 
-const COMPONENT_TEMPLATES = {
-  'Note-info':    '<Note type="info" title="情報">ここに内容を書く</Note>',
-  'Note-warning': '<Note type="warning" title="注意">ここに内容を書く</Note>',
-  'Note-tip':     '<Note type="tip" title="ヒント">ここに内容を書く</Note>',
-  'Note-danger':  '<Note type="danger" title="警告">ここに内容を書く</Note>',
-  'LinkCard':     '<LinkCard url="https://example.com" />',
-  'Details':      '<Details summary="詳細を見る">ここに内容を書く</Details>',
-};
-
 function addImport(component) {
   const ta = document.getElementById('fm-imports');
   const line = IMPORT_MAP[component];
-  if (!ta.value.includes(line)) {
+  if (line && !ta.value.includes(line)) {
     ta.value = ta.value.trim() ? ta.value.trim() + '\n' + line : line;
   }
 }
+window.addImport = addImport;
 
-function insertComponent(type, variant) {
-  const key = variant ? `${type}-${variant}` : type;
-  const tpl = COMPONENT_TEMPLATES[key];
-  if (!tpl) return;
-  const range = quill.getSelection(true);
-  quill.clipboard.dangerouslyPasteHTML(range ? range.index : quill.getLength(), `<p>${tpl}</p>`);
-  addImport(type);  // import も自動追加
-}
+window.insertComponent = function(type, variant) {
+  if (type === 'Note') {
+    editor.chain().focus().insertContent({
+      type: 'noteBlock',
+      attrs: { type: variant || 'info', title: '' },
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'ここに内容を書く' }] }],
+    }).run();
+    addImport('Note');
+  } else if (type === 'LinkCard') {
+    editor.chain().focus().insertContent({ type: 'linkCard', attrs: { url: 'https://example.com' } }).run();
+    addImport('LinkCard');
+  } else if (type === 'Details') {
+    editor.chain().focus().insertContent({
+      type: 'detailsBlock',
+      attrs: { summary: '詳細を見る' },
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'ここに内容を書く' }] }],
+    }).run();
+    addImport('Details');
+  }
+};
 
-// ── 初期日時 ───────────────────────────────────────────────────────────────
+// ── 状態変数 ──────────────────────────────────────────────────────────────────
+let currentExt = 'md';
+let originalPath = '';
+let allPosts = [];
+
+// ── 拡張子切り替え ─────────────────────────────────────────────────────────────
+window.setExt = function(ext) {
+  currentExt = ext;
+  document.querySelectorAll('.ext-btn').forEach(b => b.classList.toggle('active', b.dataset.ext === ext));
+  document.getElementById('imports-section').classList.toggle('visible', ext === 'mdx');
+};
+
+// ── 初期日時 ───────────────────────────────────────────────────────────────────
 (function setDefaultDate() {
-  const now = new Date();
+  const now   = new Date();
   const local = new Date(now.getTime() - now.getTimezoneOffset() * 60000);
   document.getElementById('fm-date').value = local.toISOString().slice(0, 16);
 })();
 
-// ── フロントマタープレビュー文字列 ────────────────────────────────────────
+// ── Frontmatter テキスト構築（プレビュー用）──────────────────────────────────
 function buildFrontmatterText() {
   const title   = document.getElementById('fm-title').value;
   const desc    = document.getElementById('fm-desc').value;
@@ -852,27 +1271,27 @@ function buildFrontmatterText() {
   return fm;
 }
 
-// ── プレビュー ─────────────────────────────────────────────────────────────
-async function refreshPreview() {
+// ── プレビュー ─────────────────────────────────────────────────────────────────
+window.refreshPreview = async function() {
   try {
-    const res = await fetch('/api/convert', {
+    const res  = await fetch('/api/convert', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ html: quill.root.innerHTML }),
+      body: JSON.stringify({ html: editor.getHTML() }),
     });
     const data = await res.json();
     document.getElementById('preview').textContent = buildFrontmatterText() + '\n\n' + data.markdown;
   } catch (e) {
     document.getElementById('preview').textContent = 'エラー: ' + e.message;
   }
-}
+};
 
-// ── 保存 ───────────────────────────────────────────────────────────────────
-async function savePost() {
-  const title   = document.getElementById('fm-title').value.trim();
-  const slug    = document.getElementById('fm-slug').value.trim();
+// ── 保存 ───────────────────────────────────────────────────────────────────────
+window.savePost = async function() {
+  const title = document.getElementById('fm-title').value.trim();
+  const slug  = document.getElementById('fm-slug').value.trim();
   if (!title) { setStatus('タイトルを入力してください', true); return; }
-  if (!slug)  { setStatus('slug を入力してください', true);   return; }
+  if (!slug)  { setStatus('slug を入力してください',   true); return; }
 
   const dateVal = document.getElementById('fm-date').value;
   const tagsRaw = document.getElementById('fm-tags').value;
@@ -881,7 +1300,7 @@ async function savePost() {
 
   setStatus('保存中...', false);
   try {
-    const res = await fetch('/api/save', {
+    const res  = await fetch('/api/save', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -889,19 +1308,18 @@ async function savePost() {
         description: document.getElementById('fm-desc').value.trim(),
         slug,
         pubDate,
-        tags: tagsRaw.split(',').map(t => t.trim()).filter(Boolean),
-        draft: document.getElementById('fm-draft').checked,
+        tags:        tagsRaw.split(',').map(t => t.trim()).filter(Boolean),
+        draft:       document.getElementById('fm-draft').checked,
         updatedDate: updated ? updated + ':00' : '',
-        imports: document.getElementById('fm-imports').value,
-        ext: currentExt,
-        body: quill.root.innerHTML,
-        author: 'reiblast1123',
+        imports:     document.getElementById('fm-imports').value,
+        ext:         currentExt,
+        body:        editor.getHTML(),
+        author:      'reiblast1123',
         originalPath,
       }),
     });
     const data = await res.json();
     if (data.success) {
-      // 保存後は元ファイルが消えているので追跡パスを更新
       const relFromBlog = data.path.replace(/^src\/content\/blog\//, '');
       originalPath = relFromBlog;
       document.getElementById('save-path').textContent = '→ ' + data.path;
@@ -910,18 +1328,18 @@ async function savePost() {
         : (data.gitMessage ? ` | git: ${data.gitMessage}` : '');
       setStatus('保存しました ✓' + gitInfo, false);
       if (data.ogpGenerated) showOgpToast(slug);
-      await refreshPreview();
+      await window.refreshPreview();
     } else {
       setStatus('エラー: ' + (data.error || JSON.stringify(data)), true);
     }
   } catch (e) {
     setStatus('エラー: ' + e.message, true);
   }
-}
+};
 
-// ── 新規 ───────────────────────────────────────────────────────────────────
-async function newPost() {
-  if (quill.getText().trim() && !confirm('現在の内容を破棄して新規作成しますか？')) return;
+// ── 新規 ───────────────────────────────────────────────────────────────────────
+window.newPost = async function() {
+  if (editor.getText().trim() && !confirm('現在の内容を破棄して新規作成しますか？')) return;
   document.getElementById('fm-title').value   = '';
   document.getElementById('fm-desc').value    = '';
   document.getElementById('fm-slug').value    = '';
@@ -929,72 +1347,61 @@ async function newPost() {
   document.getElementById('fm-draft').checked = false;
   document.getElementById('fm-updated').value = '';
   document.getElementById('fm-imports').value = '';
-  const now = new Date();
+  const now   = new Date();
   const local = new Date(now.getTime() - now.getTimezoneOffset() * 60000);
   document.getElementById('fm-date').value = local.toISOString().slice(0, 16);
   originalPath = '';
   document.getElementById('save-path').textContent = '';
   document.getElementById('preview').textContent   = '← 「更新 ↻」で Markdown を確認';
   setStatus('', false);
-  setExt('md');
+  window.setExt('md');
   await loadTemplate();
-}
+};
 
 async function loadTemplate() {
   try {
     const res  = await fetch('/api/template');
     const data = await res.json();
-    quill.root.innerHTML = data.bodyHtml || '';
+    editor.commands.setContent(data.bodyHtml || '', false);
   } catch (_) {
-    quill.root.innerHTML = '';
+    editor.commands.setContent('', false);
   }
 }
 
-// ── ステータス表示 ─────────────────────────────────────────────────────────
+// ── ステータス ─────────────────────────────────────────────────────────────────
 function setStatus(msg, isError) {
   const el = document.getElementById('status');
   el.textContent = msg;
   el.className   = isError ? 'error' : 'success';
 }
 
-// ── 記事一覧ドロワー ───────────────────────────────────────────────────────
-async function openDrawer() {
+// ── 記事一覧ドロワー ───────────────────────────────────────────────────────────
+window.openDrawer = async function() {
   document.getElementById('drawer').classList.add('open');
   document.getElementById('drawer-overlay').classList.add('open');
   document.getElementById('drawer-search').value = '';
-  await loadPostList();
-}
-
-function closeDrawer() {
-  document.getElementById('drawer').classList.remove('open');
-  document.getElementById('drawer-overlay').classList.remove('open');
-}
-
-async function loadPostList() {
   try {
     const res = await fetch('/api/posts');
-    allPosts = await res.json();
+    allPosts  = await res.json();
     renderPostList(allPosts);
   } catch (e) {
     document.getElementById('post-list').innerHTML = `<div class="no-posts">エラー: ${e.message}</div>`;
   }
-}
+};
+
+window.closeDrawer = function() {
+  document.getElementById('drawer').classList.remove('open');
+  document.getElementById('drawer-overlay').classList.remove('open');
+};
 
 function renderPostList(posts) {
   const container = document.getElementById('post-list');
-  if (posts.length === 0) {
-    container.innerHTML = '<div class="no-posts">記事が見つかりません</div>';
-    return;
-  }
-
-  // 年ごとにグループ化
+  if (posts.length === 0) { container.innerHTML = '<div class="no-posts">記事が見つかりません</div>'; return; }
   const groups = {};
   for (const post of posts) {
     const year = post.path.slice(0, 4);
-    if (!groups[year]) groups[year] = [];
-    groups[year].push(post);
+    (groups[year] = groups[year] || []).push(post);
   }
-
   let html = '';
   for (const year of Object.keys(groups).sort().reverse()) {
     html += `<div class="year-group">${year}</div>`;
@@ -1003,30 +1410,27 @@ function renderPostList(posts) {
       const titleEsc = escapeAttr(post.title);
       const extLabel = post.ext || '.md';
       html += `
-        <div class="post-item" id="item-${CSS.escape(post.path)}">
+        <div class="post-item">
           <div class="post-info">
             <div class="post-title">${escapeHtml(post.title)}</div>
             <div class="post-path">${escapeHtml(post.path)}</div>
           </div>
           <span class="post-ext">${extLabel}</span>
           <button class="edit-btn" onclick="editPost('${pathEsc}')">編集</button>
-          <button class="del-btn"  onclick="deletePost('${pathEsc}', '${titleEsc}')">削除</button>
+          <button class="del-btn"  onclick="deletePost('${pathEsc}','${titleEsc}')">削除</button>
         </div>`;
     }
   }
   container.innerHTML = html;
 }
 
-function filterPosts(query) {
+window.filterPosts = function(query) {
   const q = query.toLowerCase();
-  const filtered = q
-    ? allPosts.filter(p => p.title.toLowerCase().includes(q) || p.path.toLowerCase().includes(q))
-    : allPosts;
-  renderPostList(filtered);
-}
+  renderPostList(q ? allPosts.filter(p => p.title.toLowerCase().includes(q) || p.path.toLowerCase().includes(q)) : allPosts);
+};
 
-// ── 記事を読み込んで編集 ───────────────────────────────────────────────────
-async function editPost(path) {
+// ── 記事読み込み ───────────────────────────────────────────────────────────────
+window.editPost = async function(path) {
   try {
     const res  = await fetch('/api/load', {
       method: 'POST',
@@ -1045,21 +1449,22 @@ async function editPost(path) {
     document.getElementById('fm-updated').value = data.updatedDate || '';
     document.getElementById('fm-imports').value = data.imports || '';
 
-    setExt(data.ext || 'md');
-    quill.root.innerHTML = data.bodyHtml || '';
+    window.setExt(data.ext || 'md');
+    editor.commands.setContent(data.bodyHtml || '', false);
     originalPath = path;
 
     document.getElementById('save-path').textContent = '編集中: ' + path;
     document.getElementById('preview').textContent   = '← 「更新 ↻」で確認';
     setStatus('読み込みました ✓', false);
-    closeDrawer();
+    window.closeDrawer();
+    updateFmSummary();
   } catch (e) {
     alert('エラー: ' + e.message);
   }
-}
+};
 
-// ── 記事削除 ───────────────────────────────────────────────────────────────
-async function deletePost(path, title) {
+// ── 記事削除 ───────────────────────────────────────────────────────────────────
+window.deletePost = async function(path, title) {
   if (!confirm(`「${title}」を削除しますか？\n\n${path}\n\nこの操作は取り消せません。`)) return;
   try {
     const res  = await fetch('/api/delete', {
@@ -1071,64 +1476,39 @@ async function deletePost(path, title) {
     if (data.success) {
       allPosts = allPosts.filter(p => p.path !== path);
       renderPostList(allPosts);
-      // 編集中の記事を削除した場合はリセット
-      if (originalPath === path) newPost();
+      if (originalPath === path) window.newPost();
     } else {
       alert('削除エラー: ' + (data.error || ''));
     }
   } catch (e) {
     alert('エラー: ' + e.message);
   }
-}
+};
 
-// ── ユーティリティ ─────────────────────────────────────────────────────────
+// ── ユーティリティ ─────────────────────────────────────────────────────────────
 function escapeHtml(s) {
   return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 }
-function escapeAttr(s) {
-  return String(s).replace(/'/g, "\\'");
-}
+function escapeAttr(s) { return String(s).replace(/'/g, "\\'"); }
 
-// ── ツイートテンプレート ────────────────────────────────────────────────────
+// ── X（Twitter）ツイートテンプレート ─────────────────────────────────────────
 function buildTweetText(title, url, hashTags, desc) {
-  return `ブログを更新しました！📖
-
-📝${title}
-
-${desc}
-
-🔗 ${url}
-
-#エンジニアブログ${hashTags}`;
+  return `ブログを更新しました！📖\n\n📝${title}\n\n${desc}\n\n🔗 ${url}\n\n#エンジニアブログ${hashTags}`;
 }
-
 function getTweetUrl() {
   const slug = document.getElementById('fm-slug').value.trim();
-  if (!slug) return null;
-  return `https://reiblast1123.com/blog/${slug}/`;
+  return slug ? `https://reiblast1123.com/blog/${slug}/` : null;
 }
-
-/** エディタ本文の冒頭1行（見出し要素を除いた最初の段落テキスト）を返す */
 function getFirstLine() {
-  for (const el of quill.root.children) {
-    if (/^H[1-6]$/.test(el.tagName)) continue; // 見出しはスキップ
-    const text = el.textContent.trim();
-    if (text) return text;
-  }
-  return '';
+  const el = document.querySelector('.tiptap p, .tiptap h1, .tiptap h2, .tiptap h3');
+  return el ? el.textContent.trim() : '';
 }
-
-function buildTweetTemplates() {
+window.buildTweetTemplates = function() {
   const title    = document.getElementById('fm-title').value.trim() || '（タイトル未入力）';
   const url      = getTweetUrl() || 'https://reiblast1123.com/blog/...';
   const tagsRaw  = document.getElementById('fm-tags').value;
-  const hashTags = tagsRaw
-    .split(',')
-    .map(t => t.trim())
-    .filter(Boolean)
-    .map(t => ' #' + t.replace(/\s+/g, ''))
-    .join('');
-  const desc = getFirstLine() || '〈一言で内容を説明〉';
+  const hashTags = tagsRaw.split(',').map(t => t.trim()).filter(Boolean).map(t => ' #' + t.replace(/\s+/g, '')).join('');
+  const desc     = getFirstLine() || '〈一言で内容を説明〉';
 
   document.getElementById('tweet-url-preview').textContent = '🔗 ' + url;
 
@@ -1138,84 +1518,58 @@ function buildTweetTemplates() {
       <div class="tweet-card-header">
         <span class="tweet-chars" id="tweet-chars-0">-- 文字</span>
       </div>
-      <textarea class="tweet-textarea" id="tweet-text-0" rows="9"
-        oninput="updateTweetChars(0)"></textarea>
-      <button class="tweet-copy-btn" id="tweet-copy-0"
-        onclick="copyTweet(0)">コピー</button>
+      <textarea class="tweet-textarea" id="tweet-text-0" rows="9" oninput="updateTweetChars(0)"></textarea>
+      <button class="tweet-copy-btn" id="tweet-copy-0" onclick="copyTweet(0)">コピー</button>
     </div>`;
-
-  // textarea.value はinnerHTMLではなくJSで設定（エスケープ問題を回避）
   document.getElementById('tweet-text-0').value = buildTweetText(title, url, hashTags, desc);
   updateTweetChars(0);
-}
+};
 
-/** X の文字数カウント（URL は長さに関わらず23文字固定扱い） */
 function tweetLength(text) {
-  const noUrl = text.replace(/https?:\/\/[^\s]+/g, '_'.repeat(23));
-  return [...noUrl].length;
+  return [...text.replace(/https?:\/\/[^\s]+/g, '_'.repeat(23))].length;
 }
-
-function updateTweetChars(i) {
+window.updateTweetChars = function(i) {
   const text = document.getElementById(`tweet-text-${i}`).value;
   const len  = tweetLength(text);
   const el   = document.getElementById(`tweet-chars-${i}`);
   el.textContent = len + ' 文字';
   el.classList.toggle('over', len > 260);
-}
-
-async function copyTweet(i) {
+};
+window.copyTweet = async function(i) {
   const text = document.getElementById(`tweet-text-${i}`).value;
   const btn  = document.getElementById(`tweet-copy-${i}`);
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (_) {
-    // HTTP 環境・旧ブラウザのフォールバック
-    const ta = document.getElementById(`tweet-text-${i}`);
-    ta.select();
-    document.execCommand('copy');
-  }
-  btn.textContent = 'コピーしました ✓';
-  btn.classList.add('copied');
-  setTimeout(() => {
-    btn.textContent = 'コピー';
-    btn.classList.remove('copied');
-  }, 2000);
-}
-
-function openTweetDrawer() {
+  try { await navigator.clipboard.writeText(text); }
+  catch (_) { document.getElementById(`tweet-text-${i}`).select(); document.execCommand('copy'); }
+  btn.textContent = 'コピーしました ✓'; btn.classList.add('copied');
+  setTimeout(() => { btn.textContent = 'コピー'; btn.classList.remove('copied'); }, 2000);
+};
+window.openTweetDrawer = function() {
   buildTweetTemplates();
   document.getElementById('tweet-drawer').classList.add('open');
   document.getElementById('tweet-overlay').classList.add('open');
-}
-
-function closeTweetDrawer() {
+};
+window.closeTweetDrawer = function() {
   document.getElementById('tweet-drawer').classList.remove('open');
   document.getElementById('tweet-overlay').classList.remove('open');
-}
+};
 
-// ── OGP Toast ──────────────────────────────────────────────────────────────
+// ── OGP Toast ──────────────────────────────────────────────────────────────────
 let _ogpToastTimer = null;
 function showOgpToast(slug) {
   const toast = document.getElementById('ogp-toast');
-  const img   = document.getElementById('ogp-toast-img');
-  // キャッシュバスターで常に最新画像を表示
-  img.src = `/api/ogp-image/${slug}?t=${Date.now()}`;
+  document.getElementById('ogp-toast-img').src = `/api/ogp-image/${slug}?t=${Date.now()}`;
   toast.style.display = 'block';
   clearTimeout(_ogpToastTimer);
   _ogpToastTimer = setTimeout(closeOgpToast, 10000);
 }
-function closeOgpToast() {
-  document.getElementById('ogp-toast').style.display = 'none';
-}
+window.closeOgpToast = function() { document.getElementById('ogp-toast').style.display = 'none'; };
 
-// ── テーマ切替 ────────────────────────────────────────────────────────────
-function toggleTheme() {
+// ── テーマ切替 ─────────────────────────────────────────────────────────────────
+window.toggleTheme = function() {
   const light = document.body.classList.toggle('light');
   localStorage.setItem('theme', light ? 'light' : 'dark');
   document.getElementById('theme-btn').textContent = light ? '☀️' : '🌙';
-}
-
-// 初期化
+};
 (function() {
   if (localStorage.getItem('theme') === 'light') {
     document.body.classList.add('light');
@@ -1223,21 +1577,18 @@ function toggleTheme() {
   }
 })();
 
-// ── Frontmatter 折りたたみ ────────────────────────────────────────────────
-function toggleFm() {
+// ── Frontmatter 折りたたみ ────────────────────────────────────────────────────
+window.toggleFm = function() {
   const sec = document.getElementById('fm-section');
   const collapsed = sec.classList.toggle('collapsed');
   localStorage.setItem('fm-collapsed', collapsed ? '1' : '0');
-}
-
+};
 function updateFmSummary() {
   const title = document.getElementById('fm-title').value.trim();
   const slug  = document.getElementById('fm-slug').value.trim();
-  const parts = [title, slug ? `[${slug}]` : ''].filter(Boolean);
-  document.getElementById('fm-summary').textContent = parts.join('  ');
+  document.getElementById('fm-summary').textContent = [title, slug ? `[${slug}]` : ''].filter(Boolean).join('  ');
 }
-
-// 初期化：保存済み状態を復元
+window.updateFmSummary = updateFmSummary;
 (function() {
   if (localStorage.getItem('fm-collapsed') === '1') {
     document.getElementById('fm-section').classList.add('collapsed');
@@ -1245,29 +1596,27 @@ function updateFmSummary() {
   updateFmSummary();
 })();
 
-// ── Ctrl+S で保存 ──────────────────────────────────────────────────────────
+// ── キーボードショートカット ──────────────────────────────────────────────────
 document.addEventListener('keydown', e => {
-  if ((e.ctrlKey || e.metaKey) && e.key === 's') { e.preventDefault(); savePost(); }
-  if (e.key === 'Escape') { closeDrawer(); closeTweetDrawer(); }
+  if ((e.ctrlKey || e.metaKey) && e.key === 's') { e.preventDefault(); window.savePost(); }
+  if (e.key === 'Escape') { window.closeDrawer(); window.closeTweetDrawer(); }
 });
 
-// ── 公開（ブランチ作成 → コミット → プッシュ → PR 作成）─────────────────────
+// ── 公開（Branch → Push → PR）────────────────────────────────────────────────
 let _prUrl    = '';
 let _prBranch = '';
 
-async function publishPost() {
+window.publishPost = async function() {
   const slug  = document.getElementById('fm-slug').value.trim();
   const title = document.getElementById('fm-title').value.trim();
-
   if (!slug) { setStatus('slug を入力してください', true); return; }
 
   const btn = document.getElementById('publish-btn');
-  btn.disabled = true;
-  btn.textContent = '公開中...';
+  btn.disabled = true; btn.textContent = '公開中...';
   hidePublishError();
 
   try {
-    const res = await fetch('/api/publish', {
+    const res  = await fetch('/api/publish', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ slug, title }),
@@ -1276,7 +1625,7 @@ async function publishPost() {
     if (data.success) {
       _prUrl    = data.prUrl;
       _prBranch = data.branch || '';
-      document.getElementById('pr-url-text').textContent = _prUrl;
+      document.getElementById('pr-url-text').textContent  = _prUrl;
       document.getElementById('pr-modal-title').textContent = '✅ PR を作成しました';
       document.getElementById('pr-modal-desc').textContent  = 'GitHub でマージすると本番環境に公開されます。';
       document.getElementById('pr-modal-status').textContent = '';
@@ -1291,30 +1640,23 @@ async function publishPost() {
   } catch (e) {
     showPublishError('エラー: ' + e.message);
   } finally {
-    btn.disabled = false;
-    btn.textContent = '公開する →';
+    btn.disabled = false; btn.textContent = '公開する →';
   }
-}
+};
 
-function openPrUrl() {
-  if (_prUrl) window.open(_prUrl, '_blank', 'noopener');
-}
+window.openPrUrl    = function() { if (_prUrl) window.open(_prUrl, '_blank', 'noopener'); };
+window.closePrModal = function() { document.getElementById('pr-modal').classList.remove('open'); };
 
-function closePrModal() {
-  document.getElementById('pr-modal').classList.remove('open');
-}
-
-async function confirmMerge() {
-  if (!_prBranch) { return; }
+window.confirmMerge = async function() {
+  if (!_prBranch) return;
   if (!confirm(`PR をマージして本番公開します。\nブランチ (${_prBranch}) も削除されます。\nよろしいですか？`)) return;
 
   const btn = document.getElementById('merge-btn');
-  btn.disabled = true;
-  btn.textContent = 'マージ中...';
+  btn.disabled = true; btn.textContent = 'マージ中...';
   document.getElementById('pr-modal-status').textContent = '';
 
   try {
-    const res = await fetch('/api/merge', {
+    const res  = await fetch('/api/merge', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ branch: _prBranch }),
@@ -1323,21 +1665,18 @@ async function confirmMerge() {
     if (data.success) {
       document.getElementById('pr-modal-title').textContent = '🎉 マージ完了！';
       document.getElementById('pr-modal-desc').textContent  = 'Cloudflare Pages のビルドが完了すると本番に公開されます。';
-      document.getElementById('pr-modal-status').textContent = '';
       btn.textContent = 'マージ済み ✓';
       document.getElementById('pr-open-btn').style.display = 'none';
       setStatus('マージ完了 ✓', false);
     } else {
       document.getElementById('pr-modal-status').textContent = '⚠ ' + (data.error || 'マージに失敗しました');
-      btn.disabled = false;
-      btn.textContent = 'マージして公開 ✓';
+      btn.disabled = false; btn.textContent = 'マージして公開 ✓';
     }
   } catch (e) {
     document.getElementById('pr-modal-status').textContent = '⚠ エラー: ' + e.message;
-    btn.disabled = false;
-    btn.textContent = 'マージして公開 ✓';
+    btn.disabled = false; btn.textContent = 'マージして公開 ✓';
   }
-}
+};
 
 function showPublishError(msg) {
   const el = document.getElementById('publish-error');
@@ -1345,22 +1684,17 @@ function showPublishError(msg) {
   el.style.display = 'block';
   setTimeout(() => { el.style.display = 'none'; }, 8000);
 }
+function hidePublishError() { document.getElementById('publish-error').style.display = 'none'; }
 
-function hidePublishError() {
-  document.getElementById('publish-error').style.display = 'none';
-}
-
-// ── 初期ロード時にテンプレートを展開 ────────────────────────────────────────
+// ── 初期ロード ──────────────────────────────────────────────────────────────────
 loadTemplate();
 
-// ── Service Worker 登録（PWA） ───────────────────────────────────────────────
+// ── Service Worker（PWA）────────────────────────────────────────────────────────
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js', { scope: '/' })
-      .catch(() => {/* ローカル環境では失敗しても無視 */});
+    navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {});
   });
 }
-
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **blog-editor を Quill.js から TipTap 2.11.5 に完全移行**（`tools/blog-editor/`）
  - Note / LinkCard / Details コンポーネントをツールバーボタン（📝⚠💡🚨🔖📂）から挿入可能に
  - 文字色・背景ハイライトをワンクリックで適用
  - コンポーネント挿入時に自動で .mdx モードに切り替わり import 文も自動追加
  - `export const` 宣言（Rakuten アフィリエイト等）を imports エリアへ正しく分離
  - 画像 `![alt](./path)` の読み込み・保存に対応
- **Keystatic CMS PoC（Phase 1）完了**（`keystatic.config.ts`）
  - `slugField: '_path'` で title / slug がfrontmatterから消えない問題を修正
- **ドキュメント更新**（`CLAUDE.md`, `BLOG.md`, `README.md`）
  - wrangler project 名 typo 修正（`reiblast-portfolio` → `reiblast-f5-si`）
  - blog-editor TipTap セクション追加、MDX挿入手順を新UIに合わせて更新

## Test plan

- [x] `npm run build` 通過確認
- [x] `/api/template` `/api/convert` `/api/load` `/api/save` 動作確認
- [x] Note / LinkCard / Details の HTML↔MDX 双方向変換確認
- [x] 既存 MDX 記事（redmi-buds-8-lite-review）の読み込み確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)