### PR TITLE
feat: ログイン/ログアウト導線を追加

### DIFF
--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -80,6 +80,8 @@ export const prerender = true;
       transition: all 0.15s;
     }
     .header-btn:hover { border-color: var(--yellow); color: var(--yellow); }
+    .header-btn-logout { text-decoration: none; display: inline-block; }
+    .header-btn-logout:hover { border-color: #ff6b6b; color: #ff6b6b; }
     .ext-toggle { display: flex; gap: 3px; margin-left: auto; }
     .ext-btn {
       padding: 4px 12px;
@@ -727,6 +729,7 @@ export const prerender = true;
     <button class="ext-btn active" data-ext="md"  onclick="setExt('md')">index.md</button>
     <button class="ext-btn"        data-ext="mdx" onclick="setExt('mdx')">index.mdx</button>
   </div>
+  <a class="header-btn header-btn-logout" href="/cdn-cgi/access/logout" title="Cloudflare Access からログアウト">🚪 ログアウト</a>
 </header>
 
 <div class="main">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -459,6 +459,8 @@ const comingSoonProjects = [
         <p>&copy; 2026 reiblast1123. All rights reserved.</p>
         <nav class="footer-nav" aria-label="フッターリンク">
           <a href="/privacy/">プライバシーポリシー</a>
+          <span class="footer-sep" aria-hidden="true">・</span>
+          <a href="/admin/" rel="nofollow">ログイン</a>
         </nav>
       </div>
     </footer>
@@ -1575,6 +1577,12 @@ const comingSoonProjects = [
     .footer-nav a:hover {
       color: var(--primary);
       text-decoration: underline;
+    }
+
+    .footer-sep {
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+      margin: 0 0.4rem;
     }
 
     /* アニメーション無効化（ユーザー設定優先） */


### PR DESCRIPTION
## Summary

- トップページのフッターに `/admin/` へのログインリンクを追加（プライバシーポリシーの隣）
- エディタヘッダーに Cloudflare Access ログアウトボタンを追加（`/cdn-cgi/access/logout` へのリンクで `CF_Authorization` Cookie を削除）

## Test plan

- [ ] トップページ（/）フッターに「プライバシーポリシー・ログイン」が並んで表示される
- [ ] 「ログイン」クリック → Access 未認証なら GitHub OAuth、認証済みなら /admin/ に直接入れる
- [ ] /admin/ の右上に「🚪 ログアウト」が出る
- [ ] ログアウトクリック → Access からログアウトされる（再度 /admin/ に行くと OAuth にリダイレクト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)